### PR TITLE
Switch to apachectl fullstatus for compatibility with Debian, et al.

### DIFF
--- a/recap
+++ b/recap
@@ -240,10 +240,10 @@ print_sar() {
 	sar$FLAGS >> $RESOURCES_FILE
 }
 
-# print the output of "service httpd fullstatus" to the resources file
+# print the output of "apachectl fullstatus" to the resources file
 print_httpd_fullstatus() {
 	echo "Apache Status report" >> $RESOURCES_FILE
-	service httpd fullstatus >> $RESOURCES_FILE
+	apachectl fullstatus >> $RESOURCES_FILE
 }
 
 # print the output of "netstat -ntulpae" to the netstat file
@@ -470,10 +470,10 @@ run_resources_report() {
 		print_blankline $RESOURCES_FILE
 		print_sar q
 	fi
-	# check to see if service httpd fullstatus should be run
+	# check to see if apachectl fullstatus should be run
 	if [ $USEFULLSTATUS = "yes" -o $USEFULLSTATUS = "YES" ]
 	then
-		# send service httpd fullstatus output to output file
+		# send apachectl fullstatus output to output file
 		print_blankline $RESOURCES_FILE
 		print_httpd_fullstatus
 	fi


### PR DESCRIPTION
The command 'service httpd fullstatus' is incompatible with Debian and
any other distribution (and some BSDs as well?) that names the Apache
service anything other than httpd. In Debian, for example, the service is
named apache2.

The apachectl command is the best option for cross-distro usage, and
avoids issues potentially arising in the future as distros migrate from
using 'service' to using 'systemctl' for systemd.

These changes have been tested successfully on CentOS 5 (previously
working) and Debian 6 (not previously working) servers.
