### PR TITLE
clarify comments about MAXLOAD

### DIFF
--- a/recap.conf
+++ b/recap.conf
@@ -116,8 +116,9 @@ BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
 MIN_FREE_SPACE=0
 
 # max load - abort if load is higher than this value
-# increase accordingly on multi core servers
-#MAXLOAD=0.8
+# defaults to the number of logical cores
+# override by setting this to a specifc number
+#MAXLOAD=
 
 ###########################
 # DEFAULT COMMAND OPTIONS #


### PR DESCRIPTION
The config file has a commented out value of 0.8 for `MAXLOAD`.  This implies that the default value is 0.8, which isn't the case.  We should modify the comments to indicate that the value defaults to the number of CPU cores.