### PR TITLE
Change the way recaplog rotates files

### DIFF
--- a/recaplog
+++ b/recaplog
@@ -95,14 +95,18 @@ pack_old_logs() {
 		#
 		if [ $LOG_COMPRESS -eq 1 ]; then
 			print_msg DEBUG "do compress old log files"
-			cat ${BASEDIR}/${item}_${YESTERDAYDATE}-*.log | gzip > ${OUTPUTFILE}.gz
+			mkdir ${BASEDIR}/${item}_${YESTERDAYDATE}
+			mv ${BASEDIR}/${item}_${YESTERDAYDATE}-*.log ${BASEDIR}/${item}_${YESTERDAYDATE}
+			tar cvfz ${OUTPUTFILE}.tgz ${BASEDIR}/${item}_${YESTERDAYDATE}
+			rm -fr ${BASEDIR}/${item}_${YESTERDAYDATE}
 			ERRCODE=$?
-			touch -t ${YESTERDAYDATE}0000 $OUTPUTFILE.gz
+			touch -t ${YESTERDAYDATE}0000 $OUTPUTFILE.tgz
 		else
 			print_msg DEBUG "do not compress old log files"
-			cat ${BASEDIR}/${item}_${YESTERDAYDATE}-*.log > $OUTPUTFILE
+			mkdir ${BASEDIR}/${item}_${YESTERDAYDATE}
+			mv ${BASEDIR}/${item}_${YESTERDAYDATE}-*.log ${BASEDIR}/${item}_${YESTERDAYDATE}
 			ERRCODE=$?
-			touch -t ${YESTERDAYDATE}0000 $OUTPUTFILE
+			touch -t ${YESTERDAYDATE}0000 $OUTPUTFILE ${BASEDIR}/${item}_${YESTERDAYDATE}
 		fi
 		if [ $ERRCODE -eq 0 ]; then
 			for f in $(ls ${BASEDIR}/${item}_${YESTERDAYDATE}-*.log | grep -v daily); do


### PR DESCRIPTION
Hi,
The way recaplog is currently rotating files makes it really hard to use one-liners to parse files from previous days.
Can we change it to use a tgz of a folder, with the files for a particular day, instead of a single file with all the info concatenated? I don't thing this  will have much off an impact on the way it works but it will make troubleshooting issues a bit easier.
I ran into this problem while trying to troubleshoot a recurring issue on a server.

I've just changed a few lines of code to accomplish this.
I hope you find them useful and merge the pull request.

If you have any questions please let me now. 
Thanks!
