### PR TITLE
MAXLOAD Changes by Man Chung

### DIFF
--- a/recap
+++ b/recap
@@ -49,7 +49,7 @@ SNAPSHOT="no"
 BACKUP="no"
 lockdir=/var/lock/recap.lock
 BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
-MAXLOAD=$(grep -c MHz /proc/cpuinfo)
+MAXLOAD="1000"
 
 # default command options
 OPTS_DF="-x nfs"

--- a/recap.conf
+++ b/recap.conf
@@ -116,8 +116,7 @@ BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
 MIN_FREE_SPACE=0
 
 # max load - abort if load is higher than this value
-# increase accordingly on multi core servers
-#MAXLOAD=0.8
+#MAXLOAD=1000
 
 ###########################
 # DEFAULT COMMAND OPTIONS #


### PR DESCRIPTION
Setting MAXLOAD to 1000 by default, including hashed out default value in recap.conf

The most useful information is when something begins to go wrong, or the final moment before everything stops working. Lets log all the way.