### PR TITLE
Added a check to verify .mylogin.cnf file, if .my.cnf file is not used

### DIFF
--- a/recap
+++ b/recap
@@ -87,6 +87,7 @@ DOTMYDOTCNF="/root/.my.cnf"
 USEFDISK="no"
 MYSQL_PROCESS_LIST="table"
 MIN_FREE_SPACE=0
+LOGINPATH="recap"
 
 ###########################################
 ######### DEFAULT COMMAND OPTIONS #########
@@ -261,6 +262,9 @@ print_mysql() {
         if [ -d /etc/psa/.psa.shadow ]
         then
                 mysqladmin -uadmin -p`cat /etc/psa/.psa.shadow` --defaults-extra-file=$cnf status >> $MYSQL_FILE
+        elif [ -f /root/.mylogin.cnf ]
+        then
+                 mysqladmin --login-path=$LOGINPATH status >> $MYSQL_FILE
         else
 	            mysqladmin --defaults-extra-file=$cnf status >> $MYSQL_FILE
         fi
@@ -314,6 +318,9 @@ print_mysql_procs() {
 	        if [ -d /etc/psa/.psa.shadow ]
 	        then
 	                mysqladmin -uadmin -p`cat /etc/psa/.psa.shadow` --defaults-extra-file=$cnf -v processlist >> $MYSQL_FILE
+            elif [ -f /root/.mylogin.cnf ]
+            then
+                    mysqladmin --login-path=$LOGINPATH status >> $MYSQL_FILE
 	        else
 		        	mysqladmin --defaults-extra-file=$cnf -v processlist >> $MYSQL_FILE
 	        fi
@@ -331,6 +338,9 @@ print_mysql_procs() {
         if [ -d /etc/psa/.psa.shadow ]
 		then
                 mysqladmin -uadmin -p`cat /etc/psa/.psa.shadow` -v processlist >> $MYSQL_FILE
+        elif [ -f /root/.mylogin.cnf ]
+        then
+                    mysqladmin --login-path=$LOGINPATH status >> $MYSQL_FILE
         else
 	        	mysqladmin -v processlist >> $MYSQL_FILE
         fi

--- a/recap.conf
+++ b/recap.conf
@@ -79,6 +79,9 @@ USEMYSQLPROCESSLIST=yes
 USEINNODB=no
 # List custom .my.cnf paths, space separated (yes, we support multiple mysql instances :D)
 DOTMYDOTCNF=/root/.my.cnf
+
+# /root/.mylogin.cnf profile, if /root/.my.cnf is not used
+LOGINPATH=recap
 # display mysql process list in a 'table' or 'vertical'
 MYSQL_PROCESS_LIST=table
 


### PR DESCRIPTION
If servers are only configured to use login-paths current configuration fails. I've added checks to verify if .mylogin.cnf is used on the server.
Ref: https://dev.mysql.com/doc/mysql-utilities/1.6/en/mysql-utils-intro-connspec-mylogin.cnf.html