### PR TITLE
log dirs to 0700

### DIFF
--- a/recap-installer
+++ b/recap-installer
@@ -41,9 +41,9 @@ echo
 mkdir -p -m0755 $SBINDIR
 mkdir -p -m0755 $DATADIR/doc/recap-$VERSION
 mkdir -p -m0755 $SYSCONFDIR/cron.d
-mkdir -p -m0755 $LOGDIR/recap
-mkdir -p -m0755 $LOGDIR/recap/backups
-mkdir -p -m0755 $LOGDIR/recap/snapshots
+mkdir -p -m0700 $LOGDIR/recap
+mkdir -p -m0700 $LOGDIR/recap/backups
+mkdir -p -m0700 $LOGDIR/recap/snapshots
 mkdir -p -m0755 $MANPATH/man5
 mkdir -p -m0755 $MANPATH/man8
 


### PR DESCRIPTION
recap captures data as root, but then places this data in a world-readable dir, and writes world-readable log files.

This leaks possibly confidential data, such as PID mappings to listening ports, probably others.

Perhaps new system group is a good idea "logreaders" or somesuch?