### PR TITLE
Update recap-installer

### DIFF
--- a/recap-installer
+++ b/recap-installer
@@ -56,8 +56,16 @@ install -m 0644 TODO $DATADIR/doc/recap-$VERSION/
 install -m 0644 CHANGELOG $DATADIR/doc/recap-$VERSION/
 install -m 0644 COPYING $DATADIR/doc/recap-$VERSION/
 
-gzip recap.5
-gzip recap.8
+if [ -e recap.5 ]; then
+        gzip recap.5
+else
+        :
+fi
+if [ -e recap.8 ]; then
+        gzip recap.8
+else
+        :
+fi
 install -m 0644 recap.5.gz $MANPATH/man5
 install -m 0644 recap.8.gz $MANPATH/man8
 


### PR DESCRIPTION
Add if statement to ensure the recap.5 and recap.8 files exist before running gzip against them. Reasoning for this is because the first time you run recap-installer it works fine but if you run recap-installer again, it fails because it cannot find recap.5 and recap.8 since they've been gzipped to recap.5.gz and recap.8.gz.
