### PR TITLE
Fix to support mutliple DOTMYDOTCNF files using csv.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -260,7 +260,7 @@ print_mysql() {
                 mysqladmin -uadmin -p`cat /etc/psa/.psa.shadow` status >> $MYSQL_FILE
                 print_blankline $MYSQL_FILE
         else
-                for cnf in $DOTMYDOTCNF
+                for cnf in $( sed -e 's/,/ /g' <<<"${DOTMYDOTCNF}" )
                 do
                         if [ -f $cnf ]
                         then
@@ -329,7 +329,7 @@ print_mysql_procs() {
                 fi
                 print_blankline $MYSQL_FILE
         else
-                for cnf in $DOTMYDOTCNF
+                for cnf in $( sed -e 's/,/ /g' <<<"${DOTMYDOTCNF}" )
                 do
                         if [ -f $cnf ]
                         then

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -77,7 +77,10 @@ USEMYSQL=yes
 USEMYSQLPROCESSLIST=yes
 # Provide information on InnoDB (default: no)
 USEINNODB=no
-# List custom .my.cnf paths, space separated (yes, we support multiple mysql instances :D)
+# List custom .my.cnf paths, comma or space separated, examples:
+# DOTMYDOTCNF="/root/.my.cnf /root/.my2.cnf" # Space separated within quotes
+# DOTMYDOTCNF=/root/.my.cnf,/root/.my2.cnf   # Comma separated without quotes
+# DOTMYDOTCNF="/root/.my.cnf, /root/.my2 /root/.my3"   # Both within quotes
 DOTMYDOTCNF=/root/.my.cnf
 # display mysql process list in a 'table' or 'vertical'
 MYSQL_PROCESS_LIST=table


### PR DESCRIPTION
With current code:

``` bash
# bash -x $(which recap) 2>&1 |grep -P "\.my|MYDOT|mysqladmin"
+ DOTMYDOTCNF=/root/.my.cnf
++ DOTMYDOTCNF=/root/.my.cnf
++ /root/.my2.cnf
/etc/recap: line 81: /root/.my2.cnf: Permission denied
+ type -p mysqladmin
+ for cnf in '$DOTMYDOTCNF'
+ '[' -f /root/.my.cnf ']'
+ echo 'MySQL /root/.my.cnf status'
+ mysqladmin --defaults-extra-file=/root/.my.cnf status
+ for cnf in '$DOTMYDOTCNF'
+ '[' -f /root/.my.cnf ']'
+ echo 'MySQL /root/.my.cnf processes'
+ mysqladmin --defaults-extra-file=/root/.my.cnf -v processlist
```

Without support of comma separated values(currently):

``` bash
# bash -x $(which recap) 2>&1 |grep -P "\.my|MYDOT|mysqladmin"
+ DOTMYDOTCNF=/root/.my.cnf
++ DOTMYDOTCNF=/root/.my.cnf,/root/.my2.cnf
+ type -p mysqladmin
+ for cnf in '$DOTMYDOTCNF'
+ '[' -f /root/.my.cnf,/root/.my2.cnf ']'
+ echo 'MySQL /root/.my.cnf,/root/.my2.cnf for status does not exist. Please check DOTMYDOTCNF in /etc/recap'
+ for cnf in '$DOTMYDOTCNF'
+ '[' -f /root/.my.cnf,/root/.my2.cnf ']'
+ echo 'MySQL /root/.my.cnf,/root/.my2.cnf for processes does not exist. Please check DOTMYDOTCNF in /etc/recap'
```

With the fix(to add support of use of `csv` instead of spaces):

``` bash
# bash -x $(which recap) 2>&1 |grep -P "\.my|MYDOT|mysqladmin"
+ DOTMYDOTCNF=/root/.my.cnf
++ DOTMYDOTCNF=/root/.my.cnf,/root/.my2.cnf
+ type -p mysqladmin
++ echo /root/.my.cnf,/root/.my2.cnf
+ for cnf in '$(echo ${DOTMYDOTCNF} | sed -e '\''s/,/ /g'\'')'
+ '[' -f /root/.my.cnf ']'
+ echo 'MySQL /root/.my.cnf status'
+ mysqladmin --defaults-extra-file=/root/.my.cnf status
+ for cnf in '$(echo ${DOTMYDOTCNF} | sed -e '\''s/,/ /g'\'')'
+ '[' -f /root/.my2.cnf ']'
+ echo 'MySQL /root/.my2.cnf status'
+ mysqladmin --defaults-extra-file=/root/.my2.cnf status
++ echo /root/.my.cnf,/root/.my2.cnf
+ for cnf in '$(echo ${DOTMYDOTCNF} | sed -e '\''s/,/ /g'\'')'
+ '[' -f /root/.my.cnf ']'
+ echo 'MySQL /root/.my.cnf processes'
+ mysqladmin --defaults-extra-file=/root/.my.cnf -v processlist
+ for cnf in '$(echo ${DOTMYDOTCNF} | sed -e '\''s/,/ /g'\'')'
+ '[' -f /root/.my2.cnf ']'
+ echo 'MySQL /root/.my2.cnf processes'
+ mysqladmin --defaults-extra-file=/root/.my2.cnf -v processlist
```
