### PR TITLE
Include recaptool man page on build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install:
 	@install -Dm0644 src/recap.5 $(MANDIR)/man5/recap.5
 	@install -Dm0644 src/recap.8 $(MANDIR)/man8/recap.8
 	@install -Dm0644 src/recaplog.8 $(MANDIR)/man8/recaplog.8
+	@install -Dm0644 src/recaptool.8 $(MANDIR)/man8/recaptool.8
 	@echo "Installing configuration..."
 	@install -Dm0644 src/recap.conf $(SYSCONFDIR)/recap
 	@echo "Installing cron job..."
@@ -35,6 +36,7 @@ uninstall:
 	@rm -f $(MANDIR)/man5/recap.5
 	@rm -f $(MANDIR)/man8/recap.8
 	@rm -f $(MANDIR)/man8/recaplog.8
+	@rm -f $(MANDIR)/man8/recaptool.8
 	@echo "Removing configuration..."
 	@rm -f $(SYSCONFDIR)/recap
 	@echo "Removing cron job..."

--- a/util/packaging/rpm/recap.spec
+++ b/util/packaging/rpm/recap.spec
@@ -1,6 +1,6 @@
 Name: recap
 Version: 0.9.14
-Release: 1.rs%{?dist}
+Release: 2.rs%{?dist}
 Summary: System status reporting
 Group: Applications/System
 License: GPLv2
@@ -45,6 +45,7 @@ DESTDIR=%{buildroot} make install
 %{_mandir}/man5/recap.5.gz
 %{_mandir}/man8/recap.8.gz
 %{_mandir}/man8/recaplog.8.gz
+%{_mandir}/man8/recaptool.8.gz
 
 
 %post
@@ -72,6 +73,9 @@ echo "Edit /etc/cron.d/recap to change cron execution."
 
 
 %changelog
+* Fri Dec 16 2016 Tony Garcia <tony.garcia@rackspace.com> - 0.9.14-2.rs
+- Install recaptool man page
+
 * Wed May 11 2016 Ben Harper <ben.harper@rackspace.com> - 0.9.14-1.rs
 - Latest version
 - Fixing typos, removing commented old code, renaming functions


### PR DESCRIPTION
Per #66 I'm adding this PR, but since packaging relies on version tag this might be useless for building automatically the RPM, the purpose is to ensure the installer includes the new man page.