### PR TITLE
Removing duplicate call of df.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -505,8 +505,6 @@ run_resources_report() {
 	print_blankline $RESOURCES_FILE
 	print_iotop
 	print_blankline $RESOURCES_FILE
-	print_df
-	print_blankline $RESOURCES_FILE
 
 	# check to see if sar should be run
 	if [ $USESAR = "yes" -o $USESAR = "YES" ]

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -86,8 +86,8 @@ DOTMYDOTCNF=/root/.my.cnf
 MYSQL_PROCESS_LIST=table
 
 # DF REPORT
-# Use "df -h" output. This will show you a trend of disk space available on the drives. (default: no)
-USEDF=no
+# Use "df -h" output. This will show you a trend of disk space available on the drives. (default: yes)
+USEDF=yes
 
 # SLABTOP REPORT
 # Use printf "name\tactive\tnum_obj\tobj_size\thuh\n"; tail -n+2 /proc/slabinfo | awk 'size=$3*$4 {print $1"\t"$2"\t"$3"\t"$4"\t"size/1048576}' | sort -k5gr output. This will show you more information on the slab table. (default: no)


### PR DESCRIPTION
Removing the call to use `print_df` as down below the code there is an option that validates where this is needed or not to be printed: https://github.com/rackerlabs/recap/blob/master/src/recap#L543-L548.

Example of the current output in the logs when `${USEDF}` is enabled(by default is *not* enabled(https://github.com/rackerlabs/recap/blob/master/src/recap.conf#L87, https://github.com/rackerlabs/recap/blob/master/src/recap.conf#L87) and still is printing it) 

```bash
# grep -nA9 "Disk Utilization" /var/log/recap/resources_20170113-030001.log                                                                  
54:Disk Utilization
55-Filesystem     1K-blocks    Used Available Use% Mounted on
56-/dev/xvda1      20510288 9848604   9596776  51% /
57-devtmpfs          496548       0    496548   0% /dev
58-tmpfs             505624       0    505624   0% /dev/shm
59-tmpfs             505624   50904    454720  11% /run
60-tmpfs             505624       0    505624   0% /sys/fs/cgroup
61-tmpfs             101128       0    101128   0% /run/user/0
62- 
63- 
64:Disk Utilization
65-Filesystem     1K-blocks    Used Available Use% Mounted on
66-/dev/xvda1      20510288 9848604   9596776  51% /
67-devtmpfs          496548       0    496548   0% /dev
68-tmpfs             505624       0    505624   0% /dev/shm
69-tmpfs             505624   50904    454720  11% /run
70-tmpfs             505624       0    505624   0% /sys/fs/cgroup
71-tmpfs             101128       0    101128   0% /run/user/0
72- 
73-Top 10 cpu using processes

```