### PR TITLE
Makefile did not include making of doc/recap directory. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ install:
 	@echo "Installing cron job..."
 	@install -Dm0644 src/recap.cron $(DESTDIR)$(CRONDIR)/recap
 	@echo "Installing docs..."
+	@install -dm0750 $(DESTDIR)$(DOCDIR)/recap
 	@install -Dm0644 CHANGELOG README.md COPYING -t $(DESTDIR)$(DOCDIR)/recap
 	@echo "Creating log directories..."
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap


### PR DESCRIPTION
Installation failing on Ubuntu 14.04 LTS

```
$ sudo make install
Installing scripts...
Installing man pages...
Installing configuration...
Installing cron job...
Installing docs...
install: failed to access ‘/usr/local/share/doc/recap’: No such file or directory
make: *** [install] Error 1
```
