### PR TITLE
multiple makefile targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.0.0] - 2017-05-15
 - Record point-in-time CPU.
 - Multiple bug fixing on recaptool.
 - Multiple bug fixing on recap.
@@ -9,11 +9,13 @@ All notable changes to this project will be documented in this file.
 - Fix plesk mysql bug.
 - Install recaptool man page.
 - Adding specific requirements for bash(>=4) and sysstat(>=9).
+- Removing rpm spec requirements: elinks.
 - Obsoletes and provides rs-sysmon.
 - Better support for multiple mysql instances.
 - Makefile updated to allow multiple distros alignment and to include new man pages.
 - Adjust spec for Makefile.
 - Makefile now uses /usr/local as default for DESTDIR.
+- fdisk warnings(stderr) are now included in the logs(stdin).
 
 ## [0.9.14] - 2016-05-11
 - Fix #55 Code clean up, typos fixed and functions renamed

--- a/Makefile
+++ b/Makefile
@@ -9,46 +9,71 @@ CRONDIR       ?= $(SYSCONFDIR)/cron.d
 LOGDIR        ?= /var/log
 
 all:
-	@echo "Nothing to compile, run make install."
+	@echo "Nothing to compile, please choose a specific target:"
+	@echo "    install (includes install-base, install-man, and install-doc)"
+	@echo "    install-base"
+	@echo "    install-man"
+	@echo "    install-doc"
+	@echo "    uninstall (includes uninstall-base, uninstall-man, and uninstall-doc)"
+	@echo "    uninstall-base"
+	@echo "    uninstall-man"
+	@echo "    uninstall-doc"
 
-install:
+src/recap.cron:
+	@sed -e 's|@BINDIR@|$(BINDIR)|' src/recap.cron.in > src/recap.cron
+
+clean:
+	@rm -f src/recap.cron
+
+install: install-base install-man install-doc
+
+uninstall: uninstall-base uninstall-man uninstall-doc
+
+install-base: src/recap.cron
 	@echo "Installing scripts..."
 	@install -Dm0755 src/recap $(DESTDIR)$(BINDIR)/recap
 	@install -Dm0755 src/recaplog $(DESTDIR)$(BINDIR)/recaplog
 	@install -Dm0755 src/recaptool $(DESTDIR)$(BINDIR)/recaptool
-	@echo "Installing man pages..."
-	@install -Dm0644 src/recap.5 $(DESTDIR)$(MANDIR)/man5/recap.5
-	@install -Dm0644 src/recap.8 $(DESTDIR)$(MANDIR)/man8/recap.8
-	@install -Dm0644 src/recaplog.8 $(DESTDIR)$(MANDIR)/man8/recaplog.8
-	@install -Dm0644 src/recaptool.8 $(DESTDIR)$(MANDIR)/man8/recaptool.8
 	@echo "Installing configuration..."
 	@install -Dm0644 src/recap.conf $(DESTDIR)$(SYSCONFDIR)/recap
 	@echo "Installing cron job..."
 	@install -Dm0644 src/recap.cron $(DESTDIR)$(CRONDIR)/recap
-	@sed -i 's,/usr/sbin/,$(BINDIR)/,' $(DESTDIR)$(CRONDIR)/recap
-	@echo "Installing docs..."
-	@install -dm0755 $(DESTDIR)$(DOCDIR)/recap
-	@install -Dm0644 CHANGELOG.md README.md COPYING -t $(DESTDIR)$(DOCDIR)/recap
 	@echo "Creating log directories..."
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/backups
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/snapshots
 
-uninstall:
+install-man:
+	@echo "Installing man pages..."
+	@install -Dm0644 src/recap.5 $(DESTDIR)$(MANDIR)/man5/recap.5
+	@install -Dm0644 src/recap.8 $(DESTDIR)$(MANDIR)/man8/recap.8
+	@install -Dm0644 src/recaplog.8 $(DESTDIR)$(MANDIR)/man8/recaplog.8
+	@install -Dm0644 src/recaptool.8 $(DESTDIR)$(MANDIR)/man8/recaptool.8
+
+install-doc:
+	@echo "Installing docs..."
+	@install -dm0755 $(DESTDIR)$(DOCDIR)/recap
+	@install -Dm0644 CHANGELOG.md README.md COPYING -t $(DESTDIR)$(DOCDIR)/recap
+
+uninstall-base:
 	@echo "Removing scripts..."
 	@rm -f $(DESTDIR)$(BINDIR)/recap
 	@rm -f $(DESTDIR)$(BINDIR)/recaplog
 	@rm -f $(DESTDIR)$(BINDIR)/recaptool
-	@echo "Removing man pages..."
-	@rm -f $(DESTDIR)$(MANDIR)/man5/recap.5
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recap.8
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recaplog.8
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recaptool.8
-	@echo "Removing docs..."
-	@rm -Rf $(DESTDIR)$(DOCDIR)/recap
 	@echo "Removing configuration..."
 	@rm -f $(DESTDIR)$(SYSCONFDIR)/recap
 	@echo "Removing cron job..."
 	@rm -f $(DESTDIR)$(CRONDIR)/recap
 
-.PHONY: install uninstall purge
+uninstall-man:
+	@echo "Removing man pages..."
+	@rm -f $(DESTDIR)$(MANDIR)/man5/recap.5
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recap.8
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recaplog.8
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recaptool.8
+
+uninstall-doc:
+	@echo "Removing docs..."
+	@rm -Rf $(DESTDIR)$(DOCDIR)/recap
+
+.PHONY: install install-base install-man install-doc uninstall uninstall-base uninstall-man uninstall-doc clean

--- a/src/recap.cron.in
+++ b/src/recap.cron.in
@@ -2,33 +2,32 @@
 #uncomment for the files you want saved
 
 # runs at boot, backup the last set of reports generated prior to a reboot
-@reboot root /usr/sbin/recap -B
+@reboot root @BINDIR@/recap -B
 
 #The following are examples of times to run recap
 #This file should be in /etc/cron.d
 #Only uncomment or create one active line per installation
 
 #At 2am every day
-#0 2 * * * root /usr/sbin/recap
+#0 2 * * * root @BINDIR@/recap
 
 #At 2am and 2pm every day
-#0 2,14 * * * root /usr/sbin/recap
+#0 2,14 * * * root @BINDIR@/recap
 
 #At 2am, 8am, 2pm, 8pm every day
-#0 2,8,14,20 * * * root /usr/sbin/recap
+#0 2,8,14,20 * * * root @BINDIR@/recap
 
 #Every hour
-#0 * * * * root /usr/sbin/recap
+#0 * * * * root @BINDIR@/recap
 
 #Every 30 minutes
-#*/30 * * * * root /usr/sbin/recap
+#*/30 * * * * root @BINDIR@/recap
 
 #Every 10 minutes
-*/10 * * * * root /usr/sbin/recap
+*/10 * * * * root @BINDIR@/recap
 
 #Every 5 minutes
-#*/5 * * * * root /usr/sbin/recap
+#*/5 * * * * root @BINDIR@/recap
 
 # Pack and clear log files
-0 1 * * * root /usr/sbin/recaplog
-
+0 1 * * * root @BINDIR@/recaplog

--- a/util/packaging/rpm/recap.spec
+++ b/util/packaging/rpm/recap.spec
@@ -1,5 +1,5 @@
 Name: recap
-Version: 0.9.14
+Version: 1.0.0
 Release: 1.rs%{?dist}
 Summary: System status reporting
 Group: Applications/System
@@ -8,7 +8,7 @@ Url: https://github.com/rackerlabs/%{name}
 Source0: https://github.com/rackerlabs/%{name}/archive/%{version}.tar.gz
 BuildArch: noarch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires: sysstat, coreutils, procps, grep, gawk, bc, elinks, net-tools, iotop
+Requires: bash >= 4, sysstat >= 9, coreutils, procps, grep, gawk, bc, net-tools, iotop, psmisc
 Obsoletes: rs-sysmon < 0.9.5-2
 Provides: rs-sysmon = %{version}-%{release}
 
@@ -25,7 +25,7 @@ optional reporting on Apache, MySQL, and network connections.
 
 %install
 %{__rm} -rf %{buildroot}
-DESTDIR=%{buildroot} make install
+PREFIX=%{_prefix} DESTDIR=%{buildroot} make install
 
 
 %clean
@@ -47,9 +47,26 @@ DESTDIR=%{buildroot} make install
 %{_mandir}/man5/recap.5.gz
 %{_mandir}/man8/recap.8.gz
 %{_mandir}/man8/recaplog.8.gz
+%{_mandir}/man8/recaptool.8.gz
 
 
 %changelog
+* Mon May 15 2017 Tony Garcia <tony.garcia@rackspace.com> - 1.0.0-1.rs
+- Record point-in-time CPU.
+- Multiple bug fixing on recaptool.
+- Multiple bug fixing on recap.
+- Refactor of recaplog.
+- Fix plesk mysql bug.
+- Install recaptool man page.
+- Adding specific requirements for bash(>=4) and sysstat(>=9).
+- Removing rpm spec requirements: elinks.
+- Obsoletes and provides rs-sysmon.
+- Better support for multiple mysql instances.
+- Makefile updated to allow multiple distros alignment and to include new man pages.
+- Adjust spec for Makefile.
+- Makefile now uses /usr/local as default for DESTDIR.
+- fdisk warnings(stderr) are now included in the logs(stdin).
+
 * Wed May 11 2016 Ben Harper <ben.harper@rackspace.com> - 0.9.14-1.rs
 - Latest version
 - Fixing typos, removing commented old code, renaming functions

--- a/util/packaging/rpm/recap.spec
+++ b/util/packaging/rpm/recap.spec
@@ -25,7 +25,10 @@ optional reporting on Apache, MySQL, and network connections.
 
 %install
 %{__rm} -rf %{buildroot}
-PREFIX=%{_prefix} DESTDIR=%{buildroot} make install
+export PREFIX=%{_prefix}
+export DESTDIR=%{buildroot}
+make install-base
+make install-man
 
 
 %clean


### PR DESCRIPTION
In RPM spec files, putting doc files in place is handled by the %doc and %license macros.  In other words, we need to be able to explictly install everything _but_ the docs.  This change preserves the existing behavior of `make install`/`make uninstall`, but splits the actions out into separate targets.  This will allow us to only run `make install-base` and `make install-man` in the spec file.  Additionally, this change templatizes the recap.cron file and generates it appropriately.