### PR TITLE
Fixed apache fullstatus

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -468,7 +468,7 @@ run_resources_report() {
   if [[ $? -eq 0 && "${USEFULLSTATUS,,}" == "yes" ]]; then
     # send apachectl fullstatus output to output file
     print_blankline "${ITEM_FILE}"
-    print_httpd_fullstatus
+    print_httpd_fullstatus "${ITEM_FILE}"
   fi
 
   if [[ "${USEDF,,}" == "yes" ]]; then


### PR DESCRIPTION
There was a missing variable for which log to send fullstatus to.
Added variable ${ITEM_FILE} following the print_httpd_fullstatus command to resolve the issue.