### PR TITLE
Removing specific permissions for the recap logs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ install-base: src/recap.cron
 	@install -Dm0644 src/recap.cron $(DESTDIR)$(CRONDIR)/recap
 	@echo "Creating log directories..."
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap
-	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/backups
-	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/snapshots
+	@install -dm0755 $(DESTDIR)$(LOGDIR)/recap/backups
+	@install -dm0755 $(DESTDIR)$(LOGDIR)/recap/snapshots
 
 install-man:
 	@echo "Installing man pages..."

--- a/src/recap
+++ b/src/recap
@@ -93,16 +93,6 @@ USEFDISK="no"
 MYSQL_PROCESS_LIST="table"
 MIN_FREE_SPACE=0
 
-###########################################
-######### DEFAULT COMMAND OPTIONS #########
-###########################################
-
-# variables not currently documented for end users/not yet intended for use
-# if you change any of these, everything is likely to break in some ugly,
-# unpredictable way
-# set the permissions on the output directory, if we have to create it
-OUTPUTDIR_MODE="750"
-
 ##############################################
 ######### BEGIN FUNCTION DEFINITIONS #########
 ##############################################
@@ -136,7 +126,6 @@ create_output_dirs() {
   for OUTPUT_DIR in ${OUTPUT_DIRS[@]}; do
     if [[ ! -d "${OUTPUT_DIR}" ]]; then
       mkdir -p "${OUTPUT_DIR}"
-      chmod ${OUTPUTDIR_MODE} "${OUTPUT_DIR}"
     fi
   done
 }


### PR DESCRIPTION
Fix #98 

Setting regular permissions 755 instead, as there is no information in the `recap` logs that requires to be kept secret.