### PR TITLE
Redefining default settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2017-06-15
+- Align default settings on recap.conf to script defaults.
+- Default setting changed for: USEDF, USENETSTAT, OPTS_PSTREE.
+- Removed old unused settings.
+- Added new setting(OPTS_STATUSURL) to remove dependency to apache httpd.
+- Updated man pages to reflect new defaults.
+
 ## [1.0.0] - 2017-05-15
 - Record point-in-time CPU.
 - Multiple bug fixing on recaptool.
@@ -106,15 +113,19 @@ All notable changes to this project will be documented in this file.
 
 # Contributors
 - Alan Pearce
+- Andrew Howard(StafDehat)
 - Ben Harper (b-harper)
 - Benjamin H. Graham (bhgraham)
 - Blake Moore
 - Brandon Tomlinson (thebwt)
 - Brent A. Oswald (buzzboy23)
 - Carl George (carlwgeorge)
+- Carl Thompson(redragon)
 - Christian (thtieig)
 - Cian Brennan (lil-cain)
+- David King
 - Erik Ljungstrom
+- Jacob Walcik
 - James Belchamber
 - Sean Dennis (jamrok)
 - Jay Goldberg

--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ in /etc/recap
 
 ```
 DATE=`date +%Y-%m-%d_%H:%M:%S
-ROTATE="7"
 ```
 
 `DATE` is the format of the date header at the top of the reports/email
-
-`ROTATE` is the number of files to maintain for rotation purposes
 
 Additional optional variables are as follows:
 

--- a/src/recap
+++ b/src/recap
@@ -84,6 +84,7 @@ USEINNODB="no"
 USEMYSQLPROCESSLIST="no"
 
 # Default command options(can be overriden in config file)
+OPTS_CURL="-Ls"
 OPTS_DF="-x nfs"
 OPTS_FDISK="-l"
 OPTS_FREE=""
@@ -237,7 +238,7 @@ print_sar() {
 print_http_fullstatus() {
   local LOGFILE="$1"
   echo "Web Status report" >> "${LOGFILE}"
-  curl -Ls "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
+  curl ${OPTS_CURL} "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
 }
 
 # Print the output of "netstat -ntulpae" to the specified file

--- a/src/recap
+++ b/src/recap
@@ -40,23 +40,50 @@
 # DO NOT change these values here, user-modifiable options can be tweaked through
 # /etc/recap
 
-#####################################
-######### BASIC ENVIRONMENT #########
-#####################################
-
-# define our basic environment
-LOG_SUFFIX=$(date +%Y%m%d-%H%M%S)
+## Default settings(can *NOT* be overriden in config file)
+declare -r DATE=$( date +%F_%T )
+declare -r LOCKFILE="/var/lock/recap.lock"
+declare -r LOG_SUFFIX=$( date +%Y%m%d-%H%M%S )
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
-BASEDIR="/var/log/recap"
-DATE=`date +%Y-%m-%d_%H:%M:%S`
-ROTATELOGS="yes"
-SNAPSHOT="no"
-BACKUP="no"
-LOCKFILE="/var/lock/recap.lock"
-BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
-MAXLOAD="1000"
 
-# default command options
+## Default settings(modified through command line arguments)
+BACKUP="no"
+SNAPSHOT="no"
+
+## Default settings(can be overridden in config file)
+BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
+BASEDIR="/var/log/recap"
+MAILTO=""
+MAXLOAD=$(( $( grep -c sibling /proc/cpuinfo ) * 10 ))
+MIN_FREE_SPACE=0
+USEFDISK="no"
+USEPS="yes"
+USEPSTREE="no"
+USESLAB="no"
+
+# Parent setting(other settings depend on this)
+USERESOURCES="yes"
+# These depend on USERRESOURCES to be enabled("yes")
+USEDF="yes"
+USEFULLSTATUS="no"
+USESAR="yes"
+USESARQ="no"
+USESARR="no"
+
+# Parent setting(other settings depend on this)
+USENETSTAT="yes"
+# These depend on USENETSTAT to be enabled("yes")
+USENETSTATSUM="no"
+
+# Parent setting(other settings depend on this)
+USEMYSQL="no"
+# These depend on USEMYSQL to be enabled("yes")
+DOTMYDOTCNF="/root/.my.cnf"
+MYSQL_PROCESS_LIST="table"
+USEINNODB="no"
+USEMYSQLPROCESSLIST="no"
+
+# Default command options(can be overriden in config file)
 OPTS_DF="-x nfs"
 OPTS_FDISK="-l"
 OPTS_FREE=""
@@ -65,38 +92,11 @@ OPTS_IOTOP="-b -o -t -n 3"
 OPTS_NETSTAT="-ntulpae"
 OPTS_NETSTAT_SUM="-s"
 OPTS_PS="auxfww"
-OPTS_PSTREE=""
+OPTS_PSTREE="-p"
 OPTS_VMSTAT="-S M 1 3"
+OPTS_STATUSURL="http://localhost:80/"
 
-################################################
-######### DEFAULT VALUES FOR VARIABLES #########
-################################################
-
-# set defaults (can be overridden in /etc/recap)
-USEPS="yes"
-USERESOURCES="yes"
-USESAR="no"
-USESARR="no"
-USESARQ="no"
-USEFULLSTATUS="no"
-ROTATE="7"
-USEPSTREE="no"
-USENETSTAT="no"
-USENETSTATSUM="no"
-USEMYSQL="no"
-USEMYSQLPROCESSLIST="no"
-USEDF="no"
-USESLAB="no"
-USEINNODB="no"
-DOTMYDOTCNF="/root/.my.cnf"
-USEFDISK="no"
-MYSQL_PROCESS_LIST="table"
-MIN_FREE_SPACE=0
-
-##############################################
-######### BEGIN FUNCTION DEFINITIONS #########
-##############################################
-
+# Functions
 
 # Cleanup function to remove lock
 cleanup() {
@@ -115,7 +115,7 @@ recaplock() {
   fi
 }
 
-# ensure our output directories exist before we start creating files
+# Ensure our output directories exist before we start creating files
 create_output_dirs() {
   BACKUPDIR="${BASEDIR}/backups"
   SNAPSHOTSDIR="${BASEDIR}/snapshots"
@@ -130,7 +130,7 @@ create_output_dirs() {
   done
 }
 
-# print the usage definition for the script
+# Print the usage definition for the script
 print_usage() {
 	echo "Usage: recap [OPTION]"
 	echo "Takes a snapshot of running processes and resource usage"
@@ -141,7 +141,7 @@ print_usage() {
 	echo "-S, --snapshot		take a timestamped snapshot outside of the regular output file rotation"
 }
 
-# create output file
+# Create output file
 create_output_file() {
   local OUTPUT_FILE="$1"
   if [[ -d "${OUTPUT_FILE}" ]]; then
@@ -153,7 +153,7 @@ create_output_file() {
   fi
 }
 
-# check to see if the output directory exists
+# Check to see if the output directory exists
 check_output_file() {
   local OUTPUT_FILE="$1"
   if [[ ! -r "${OUTPUT_FILE}" ]]; then
@@ -162,60 +162,60 @@ check_output_file() {
   fi
 }
 
-# print output of "ps auxfww" to the specified file
+# Print output of "ps auxfww" to the specified file
 print_ps() {
   local LOGFILE="$1"
   ps ${OPTS_PS} >> "${LOGFILE}"
 }
 
-# print output of "pstree" to specified file
+# Print output of "pstree" to specified file
 print_pstree() {
   local LOGFILE="$1"
   pstree ${OPTS_PSTREE} >> "${LOGFILE}"
 }
 
-# print a blank line to the specified file
+# Print a blank line to the specified file
 print_blankline() {
   local LOGFILE="$1"
   echo " " >> "${LOGFILE}"
 }
 
-# print the output of "uptime" to the specified file
+# Print the output of "uptime" to the specified file
 print_uptime() {
   local LOGFILE="$1"
   echo "UPTIME report" >> "${LOGFILE}"
   uptime >> "${LOGFILE}"
 }
 
-# print the output of "free" to the specified file
+# Print the output of "free" to the specified file
 print_free() {
   local LOGFILE="$1"
   echo "FREE report" >> "${LOGFILE}"
   free ${OPTS_FREE} >> "${LOGFILE}"
 }
 
-# print the output of "vmstat" to the specified file
+# Print the output of "vmstat" to the specified file
 print_vmstat() {
   local LOGFILE="$1"
   echo "VMSTAT report" >> "${LOGFILE}"
   vmstat ${OPTS_VMSTAT} >> "${LOGFILE}"
 }
 
-# print the output of "iostat" to the specified file
+# Print the output of "iostat" to the specified file
 print_iostat() {
   local LOGFILE="$1"
   echo "IOSTAT report" >> "${LOGFILE}"
   iostat ${OPTS_IOSTAT} >> "${LOGFILE}"
 }
 
-# print the output of "iotop" to the specified file
+# Print the output of "iotop" to the specified file
 print_iotop() {
   local LOGFILE="$1"
   echo "IOTOP report" >> "${LOGFILE}"
   iotop ${OPTS_IOTOP} >> "${LOGFILE}"
 }
 
-# print the output of sar to the specified file
+# Print the output of sar to the specified file
 print_sar() {
   local LOGFILE="$1"
   local OPTION="$2"
@@ -233,28 +233,28 @@ print_sar() {
   sar "${FLAGS}" >> "${LOGFILE}"
 }
 
-# print the output of "apachectl fullstatus" to the specified file
-print_httpd_fullstatus() {
+# Print the output of the web server status page to the specified file
+print_http_fullstatus() {
   local LOGFILE="$1"
-  echo "Apache Status report" >> "${LOGFILE}"
-  apachectl fullstatus >> "${LOGFILE}"
+  echo "Web Status report" >> "${LOGFILE}"
+  curl -Ls "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
 }
 
-# print the output of "netstat -ntulpae" to the specified file
+# Print the output of "netstat -ntulpae" to the specified file
 print_netstat() {
   local LOGFILE="$1"
   echo "Network connections" >> "${LOGFILE}"
   netstat ${OPTS_NETSTAT} >> "${LOGFILE}"
 }
 
-# print the output of "netstat -s" to the specified file
+# Print the output of "netstat -s" to the specified file
 print_netstat_sum() {
   local LOGFILE="$1"
   echo "Network traffic summary" >> "${LOGFILE}"
   netstat ${OPTS_NETSTAT_SUM} >> "${LOGFILE}"
 }
 
-# print the output of "mysqladmin status" to the mysql file
+# Print the output of "mysqladmin status" to the mysql file
 print_mysql() {
   local LOGFILE="$1"
   local PLESK_FILE="/etc/psa/.psa.shadow"
@@ -268,7 +268,7 @@ print_mysql() {
   print_blankline "${LOGFILE}"
 }
 
-# print the non-truncated innodb status to the mysql file
+# Print the non-truncated innodb status to the mysql file
 print_mysql_innodb_status() {
   local LOGFILE="$1"
   # First, we establish which tmpdir and pid_file are in use, strip any
@@ -302,17 +302,17 @@ print_mysql_innodb_status() {
   done
 }
 
-# print the output of "mysqladmin processlist" to the mysql file
+# Print the output of "mysqladmin processlist" to the mysql file
 print_mysql_procs() {
   local LOGFILE="$1"
   local PLESK_FILE="/etc/psa/.psa.shadow"
   if [[ -r "${PLESK_FILE}" ]]; then
     echo "MySQL processes" >> "${LOGFILE}"
-    if [[ ${MYSQL_PROCESS_LIST} == "table" ]]; then
+    if [[ ${MYSQL_PROCESS_LIST,,} == "table" ]]; then
       mysqladmin -uadmin -p$( cat "${PLESK_FILE}" ) -v processlist \
         >> "${LOGFILE}"
     fi
-    if [[ ${MYSQL_PROCESS_LIST} == "vertical" ]]; then
+    if [[ ${MYSQL_PROCESS_LIST,,} == "vertical" ]]; then
       mysql -uadmin -p$( cat "${PLESK_FILE}" ) -e "show full processlist\G" \
         >> "${LOGFILE}"
     fi
@@ -321,7 +321,7 @@ print_mysql_procs() {
     if [[ ${MYSQL_PROCESS_LIST} == "table" ]]; then
       mysqladmin --defaults-extra-file="${DOTMYDOTCNF}" -v processlist \
         >> "${LOGFILE}"
-    elif [[ ${MYSQL_PROCESS_LIST} == "vertical" ]]; then
+    elif [[ ${MYSQL_PROCESS_LIST,,} == "vertical" ]]; then
       mysql --defaults-extra-file="${DOTMYDOTCNF}" \
             -e "show full processlist\G" >> "${LOGFILE}"
     fi
@@ -329,7 +329,7 @@ print_mysql_procs() {
   print_blankline "${LOGFILE}"
 }
 
-# print the top 10 processes (by cpu usage) to the defined file
+# Print the top 10 processes (by cpu usage) to the defined file
 print_top_10_cpu() {
   local LOGFILE="$1"
   local pidstat_cpufield=0
@@ -351,28 +351,28 @@ print_top_10_cpu() {
     head -11 >> "${LOGFILE}"
 }
 
-# print the top 10 processes (by memory usage) to the defined file
+# Print the top 10 processes (by memory usage) to the defined file
 print_top_10_mem() {
   local LOGFILE="$1"
   echo "Top 10 memory using processes" >> "${LOGFILE}"
   ps auxww --sort=-rss | head -11 >> "${LOGFILE}"
 }
 
-# print the disk utilization to the defined file
+# Print the disk utilization to the defined file
 print_df() {
   local LOGFILE="$1"
   echo "Disk Utilization" >> "${LOGFILE}"
   df ${OPTS_DF} >> "${LOGFILE}"
 }
 
-# print the disk partitions to the fdisk file
+# Print the disk partitions to the fdisk file
 print_fdisk() {
   local LOGFILE="$1"
   echo "Disk partitions" >> "${LOGFILE}"
   fdisk ${OPTS_FDISK} 2>&1 >> "${LOGFILE}"
 }
 
-# print the slabinfo command to the defined file
+# Print the slabinfo command to the defined file
 print_slabinfo() {
   local LOGFILE="$1"
   echo "Slab Information" >> "${LOGFILE}"
@@ -382,7 +382,7 @@ print_slabinfo() {
     sort -k5gr >> "${LOGFILE}"
 }
 
-# send the report via email
+# Send the report via email
 send_mail() {
   # create a temp directory
   local TEMPDIR=$( mktemp -d "/tmp/rs.XXXXXXXXXX" )
@@ -411,13 +411,13 @@ send_mail() {
   fi
 }
 
-# manage item report
+# Manage item report
 run_item_report() {
   local item="$1"
   local ITEM_FILE="${BASEDIR}/${item}_${LOG_SUFFIX}.log"
 
   if [[ "${SNAPSHOT,,}" == "yes" ]]; then
-    ITEM_FILE="${SNAPSHOTSDIR}/${item}.log_snapshot_${DATE}"
+    ITEM_FILE="${SNAPSHOTSDIR}/${item}_${LOG_SUFFIX}.log_snapshot"
   fi
 
   create_output_file "${ITEM_FILE}"
@@ -425,13 +425,13 @@ run_item_report() {
   eval "print_${item}" "${ITEM_FILE}"
 }
 
-# manage resources report
+# Manage resources report
 run_resources_report() {
   local item="resources"
   local ITEM_FILE="${BASEDIR}/${item}_${LOG_SUFFIX}.log"
 
   if [[ "${SNAPSHOT,,}" == "yes" ]]; then
-    ITEM_FILE="${SNAPSHOTSDIR}/${item}.log_snapshot_${DATE}"
+    ITEM_FILE="${SNAPSHOTSDIR}/${item}_${LOG_SUFFIX}.log_snapshot"
   fi
 
   create_output_file "${ITEM_FILE}"
@@ -467,12 +467,11 @@ run_resources_report() {
     print_sar "${ITEM_FILE}" "q"
   fi
 
-  # check to see if apachectl fullstatus should be run
-  type -p 'apachectl' > /dev/null
+  # check to see if webserver fullstatus should be run
+  type -p 'curl' > /dev/null
   if [[ $? -eq 0 && "${USEFULLSTATUS,,}" == "yes" ]]; then
-    # send apachectl fullstatus output to output file
     print_blankline "${ITEM_FILE}"
-    print_httpd_fullstatus "${ITEM_FILE}"
+    print_http_fullstatus "${ITEM_FILE}"
   fi
 
   if [[ "${USEDF,,}" == "yes" ]]; then
@@ -493,13 +492,13 @@ run_resources_report() {
   print_top_10_mem "${ITEM_FILE}"
 }
 
-# manage netstat report
+# Manage netstat report
 run_netstat_report() {
   local item="netstat"
   local ITEM_FILE="${BASEDIR}/${item}_${LOG_SUFFIX}.log"
 
   if [[ "${SNAPSHOT,,}" == "yes" ]]; then
-    ITEM_FILE="${SNAPSHOTSDIR}/${item}.log_snapshot_${DATE}"
+    ITEM_FILE="${SNAPSHOTSDIR}/${item}_${LOG_SUFFIX}.log_snapshot"
   fi
 
   create_output_file "${ITEM_FILE}"
@@ -513,13 +512,13 @@ run_netstat_report() {
   fi
 }
 
-# manage mysql report
+# Manage mysql report
 run_mysql_report() {
   local item="mysql"
   local ITEM_FILE="${BASEDIR}/${item}_${LOG_SUFFIX}.log"
 
   if [[ "${SNAPSHOT,,}" == "yes" ]]; then
-    ITEM_FILE="${SNAPSHOTSDIR}/${item}.log_snapshot_${DATE}"
+    ITEM_FILE="${SNAPSHOTSDIR}/${item}_${LOG_SUFFIX}.log_snapshot"
   fi
 
   create_output_file "${ITEM_FILE}"
@@ -545,7 +544,7 @@ run_mysql_report() {
   fi
 }
 
-# copy the last log file set to ${BACKUPDIR}
+# Copy the last log file set to ${BACKUPDIR}
 create_backup() {
   for log_file in ${BACKUP_ITEMS}; do
     ls -1t ${BASEDIR}/${log_file}_*.log |
@@ -554,7 +553,7 @@ create_backup() {
   done
 }
 
-# check enough disk space is free
+# Check enough disk space is free
 check_disk_space() {
   if [[ ${MIN_FREE_SPACE} -eq 0 ]]; then
     return 0
@@ -567,12 +566,10 @@ check_disk_space() {
   fi
 }
 
-###############################################
-######### BEGIN EXECUTING SCRIPT HERE #########
-###############################################
+## Main
 
-# check to see where the configuration file is located.
-# if the file is not at /etc/recap, make some noise to alert users
+# Check to see where the configuration file is located.
+# If the file is not at /etc/recap, make some noise to alert users
 if [ -r /etc/sysconfig/recap ] && [ -r /etc/recap ]
 then
 	echo "Configuration files exist at old (/etc/sysconfig/recap) and new locations (/etc/recap). The file from the old location will be read. Please consolidate your configuration details into /etc/recap."
@@ -596,22 +593,20 @@ if [[ ${QUIT} -eq 1 ]]; then
   exit 1
 fi
 
-# verify that script is being run as root
+# Verify that script is being run as root
 if [[ "$(id -u)" != "0" ]]; then
   echo "This script must be run as root."
   exit
 fi
 
-# evaluate input flags
-# if we have more than one flag, print usage and exit
+# Evaluate input flags, print usage if more than one flag is used.
 if [[ "$#" -gt 1 ]]; then
  echo "Only one flag is allowed"
  print_usage
  exit
 fi
 
-# if we only have one flag, see if we know how to handle it.
-# otherwise, print usage and exit
+# If we only have one flag, see if we know how to handle it.
 if [[ "$#" -gt 0 ]]; then
   case "$1" in
     -B|--backup)
@@ -625,7 +620,6 @@ if [[ "$#" -gt 0 ]]; then
       ;;
     -S|--snapshot)
       # take a snapshot outside of the regular output rotation
-      ROTATELOGS="no"
       SNAPSHOT="yes"
       ;;
     *)
@@ -638,69 +632,62 @@ fi
 
 check_disk_space
 
-# grab the server's host name
+# Grab the server's host name
 HOSTNAME="$( hostname )"
 
-# create output directory if it is not already present
+# Create output directory if it is not already present
 create_output_dirs
 
-# take a backup?
+# Take a backup
 if [[ "${BACKUP,,}" == "yes" ]]; then
   create_backup
   exit 0
 fi
 
-# proceed to report generation
+## Proceed to report generation
 
-###################################################################################
-# To add new reports, do the following:						  #
-# -Add a "USE[ string ]" variable at the top of this script to default the report #
-#  to on or off (yes or no).							  #
-# -Define a "run_[ string ]" function above that generates the report file	  #
-# -Define any supplemental functions necessary for generating the report	  #
-# -Add an "if" block below that calls the appropriate "run_[ string ]" function   #
-# -Update the documentation to reflect the new report				  #
-###################################################################################
-
+# Create lock
 recaplock
-# run the ps report
+
+# Run the ps report
 if [[ "${USEPS,,}" == "yes" ]]; then
   run_item_report "ps"
 fi
 
-# run the resources report
+# Run the resources report
 #TODO: standardize the run_resources_report
 if [[ "${USERESOURCES,,}" == "yes" ]]; then
   run_resources_report
 fi
 
-# run the pstree report
+# Run the pstree report
 if [[ "${USEPSTREE,,}" == "yes" ]]; then
   run_item_report "pstree"
 fi
 
-# run the netstat report
+# Run the netstat report
 #TODO: standardize the run_netstat_report
 if [[ "${USENETSTAT,,}" == "yes" ]]; then
   run_netstat_report
 fi
 
-# run the fdisk report
+# Run the fdisk report
 if [[ "${USEFDISK,,}" == "yes" ]]; then
   run_item_report "fdisk"
 fi
 
-# run the mysql report
+# Run the mysql report
 #TODO: standardize the run_mysql_report
 type -p 'mysqladmin' > /dev/null
 if [[ $? -eq 0 && "${USEMYSQL,,}" == "yes" ]]; then
   run_mysql_report
 fi
 
-# check to see if report should be emailed
-if [[ ! "${MAILTO}" == '' ]]; then
+# Check to see if report should be emailed
+#TODO: Validate MAILTO format.
+if [[ -n "${MAILTO}" ]]; then
   send_mail
 fi
 
-# we're done, time to exit
+# We're done, time to exit
 exit

--- a/src/recap.5
+++ b/src/recap.5
@@ -151,6 +151,11 @@ Option required by USEMYSQL, USEMYSQLPROCESSLIST, USEINNODB, defines the path to
 Format to display MySQL process list, options are "table" or "vertical". This requires that USEMYSQLPROCESSLIST be set "yes".
 (default: table).
 
+.IP \fBOPTS_CURL\fR
+.br
+Options used by curl, when using USEFULLSTATUS
+(default: '-Ls')
+
 .IP \fBOPTS_DF\fR
 .br
 df options

--- a/src/recap.5
+++ b/src/recap.5
@@ -19,7 +19,7 @@
 .\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 .\" Boston, MA 02110-1301 USA.
 .\"
-.TH RECAP 5 "October 31, 2013"
+.TH RECAP 5 "July 7, 2017"
 .SH NAME
 recap \- dumps periodic information about running applications and resource usage
 .SH SYNOPSIS
@@ -30,25 +30,42 @@ recap is a user-configurable script that can be run once, or run periodically ou
 The default values for which reports are generated and how many reports are stored can be
 .IR /etc/recap "."
 The output files from the script are written to
-.IR /var/log/recap "."
+.IR BASEDIR "."
 .SH OPTIONS
 .LP
+
+.IP \fBBACKUP_ITEMS\fR
+.br
+The list of reports to be generated and used by recap scripts. Currently this list is used in conjunction with the "USE___" variables to generate a report.
+(default: "fdisk mysql netstat ps pstree resources")
+
+.IP \fBBASEDIR\fR
+.br
+Directory where recap logs will be written, if defined is used by recaplog and recaptool.
+(default: /var/log/recap)
+
 .IP \fBMAILTO\fR
 .br
 Define this variable if you would like the reports to be sent via email
 
-.IP \fBMYSQL_PROCESS_LIST\fR
+IP \fBMAXLOAD\fR
 .br
-"table" to display MySQL process list as a table, "vertical" to display process list vertically
-(default: table)
+The maximum load allowed to run recap, abort if load is higher than this value. Default is calculated dynamically 10 times the number of CPUs identified by the kernel.
+(default: 10*CPUs)
 
-.IP \fBROTATE\fR
+.IP \fBMIN_FREE_SPACE\fR
 .br
-By default, the last seven result sets will be stored. If you define this value you can set it equal to any integer in order to keep a larger or smaller set of data.
+The minimum free disk space (in MB) required in ${BASEDIR} to run recap. (Disabled by default)
+(default: 0)
 
+.PP
+REPORTS
+.RS 4
 .IP \fBUSEFDISK\fR
 .br
-Can be set to yes or no to enable or not the fdisk.log. (default: no)
+Can be set to yes or no to enable or not "fdisk ${OPTS_FDISK}. This output is written in
+.IR ${BASEDIR}/fdisk.log
+(default: no)
 
 .IP \fBUSEPS\fR
 .br
@@ -58,106 +75,143 @@ Can be set to yes or no to enable or disable the ps.log. (default: yes)
 .br
 Can be set to yes or no to enable or disable the resources.log. (default: yes)
 
+.IP \fBUSEDF\fR
+.br
+Can be set to yes or no depending on whether or not "df ${OPTS_DF}" output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: yes)
+
+.IP \fBUSESLAB\fR
+.br
+Can be set to yes or no depending on whether or not the slab counters should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
+
 .IP \fBUSESAR\fR
 .br
-Can be set to yes or no depending on whether or not "sar" output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
-
-.IP \fBUSESARR\fR
-.br
-Can be set to yes or no depending on whether or not "sar -r" output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
+Can be set to yes or no depending on whether or not "sar" output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: yes)
 
 .IP \fBUSESARQ\fR
 .br
-Can be set to yes or no depending on whether or not "sar -q" output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
+Can be set to yes or no depending on whether or not "sar -q"(Queue lenght, load) output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
+
+.IP \fBUSESARR\fR
+.br
+Can be set to yes or no depending on whether or not "sar -r"(memory data) output should be stored in the report output. This requires that USERESOURCES be set to yes. (default: no)
 
 .IP \fBUSEFULLSTATUS\fR
 .br
-Can be set to yes or no depending on whether or not the output of "service httpd fullstatus" should be recorded. Before enabling this option, please make sure that the http://localhost/server-status URL is accessible and that the ExtendedStatus directive is turned on in the Apache configuration. This requires that USERESOURCES be set to yes. (default: no)
+Can be set to yes or no depending on whether or not a http request(GET) to OPTS_STATUSURL is required, it requires that the webserver url(OPTS_STATUSURL) is configured to respond to this request. Nginx(nginx_status) and Apache HTTPD(server-status) offer a functionality to provide the status of the webserver via URL. This requires that USERESOURCES be set to yes. (default: no)
 
 .IP \fBUSEPSTREE\fR
 .br
-Can be set to yes or no depending on whether or not the output of the "pstree" command should be recorded. Please note that this output is written to a separate file in
-.IR /var/log/recap/
-named
-.IR pstree.log
+Can be set to yes or no depending on whether or not the output of the "pstree" command should be recorded. Makes use of OPTS_PSTREE to modify its options. Please note that this output is written to a separate file in
+.IR ${BASEDIR}/pstree.log
 (default: no)
 
 .IP \fBUSENETSTAT\fR
 .br
-Can be set to yes or no depending on whether or not the output of "netstat -ntulpae" command should be recorded. Please note that this output is written to a separate file in
-.IR /var/log/recap/
-named
-.IR netstat.log
-(default: no)
+Can be set to yes or no depending on whether or not the output of "netstat ${OPTS_NETSTAT}" command should be recorded. Please note that this output is written to a separate file in
+.IR ${BASEDIR}/netstat.log
+is required by USENETSTATSUM.
+(default: yes)
 
 .IP \fBUSENETSTATSUM\fR
 .br
-Can be set to yes or no depending on whether or not the output of "netstat -s" command should be recorded. This report requires that USENETSTAT be set to "yes". Please note that this output is written to a separate file in
-.IR /var/log/recap/
-named
-.IR netstat.log
+Can be set to yes or no depending on whether or not the output of "netstat ${OPTS_NETSTAT_SUM}" command should be recorded. This report requires that USENETSTAT be set to "yes". This output is written in
+.IR ${BASEDIR}/netstat.log
 (default: no)
 
 .IP \fBUSEMYSQL\fR
 .br
-Can be set to yes or no depending on whether or not the output of "mysqladmin status" command should be recorded. Before enabling this option, please make sure that the ~root/.my.cnf has appropriate credentials for accessing MySQL. Please note that this output is written to a separate file in
-.IR /var/log/recap/
-named
-.IR mysql.log
+Can be set to yes or no depending on whether or not the output of "mysqladmin status" command should be recorded. Before enabling this option, please make sure that DOTMYDOTCNF points to the file that has appropriate credentials for accessing MySQL. Please note that this output is written to a separate file in
+.IR ${BASEDIR}/mysql.log
 (default: no)
 
 .IP \fBUSEMYSQLPROCESSLIST\fR
 .br
-Can be set to yes or no depending on whether or not the output of "mysqladmin status" command should be recorded. This report requires that USEMYSQL be set to "yes". Please note that this output is written to a separate file in
-.IR /var/log/recap/
-named
-.IR mysql.log
+Can be set to yes or no depending on whether or not the output of "mysqladmin processlist" command should be recorded. This report requires that USEMYSQL be set to "yes". This option makes use of MYSQL_PROCESS_LIST, to produce the output vertical or in a table. This output is written in
+.IR ${BASEDIR}/mysql.log
 (default: no)
 
-.SH DEFAULT COMMAND LINE OPTIONS
-.LP
+.IP \fBUSEINNODB\fR
+.br
+Can be set to yes or no depending on whether or not the output of "mysql show engine innodb status" and other variables(pid_files, tmpdir) command should be recorded. This report requires that USEMYSQL be set to "yes". This output is written in
+.IR ${BASEDIR}/mysql.log
+(default: no)
+
+.PP
+COMMAND OPTIONS
+.RS 4
+Options used by the tools generating the reports
+
+.IP \fBDOTMYDOTCNF\fR
+.br
+Option required by USEMYSQL, USEMYSQLPROCESSLIST, USEINNODB, defines the path to the mysql client configuration file.
+(default: "/root/.my.cnf")
+
+.IP \fBMYSQL_PROCESS_LIST\fR
+.br
+Format to display MySQL process list, options are "table" or "vertical". This requires that USEMYSQLPROCESSLIST be set "yes".
+(default: table).
+
 .IP \fBOPTS_DF\fR
 .br
 df options
+(default: '-x nfs')
 
 .IP \fBOPTS_FDISK\fR
 .br
-fdisk options
+Option used by USEFDISK.
+(default: "-l")
 
 .IP \fBOPTS_FREE\fR
 .br
 free options
+(default: "")
 
 .IP \fBOPTS_IOSTAT\fR
 .br
 iostat options
+(default: "-t -x 1 3" )
 
 .IP \fBOPTS_IOTOP\fR
 .br
 iotop options
+(default: "-b -o -t -n 3")
 
 .IP \fBOPTS_NETSTAT\fR
 .br
 netstat options
+(default: "-ntulpae")
 
 .IP \fBOPTS_NETSTAT_SUM\fR
 .br
 netstat statics options
+(default: "-s")
 
 .IP \fBOPTS_PS\fR
 .br
 ps options
+(default: "auxfww")
 
 .IP \fBOPTS_PSTREE\fR
 .br
 pstree options
+(default: "-p")
+
+.IP \fBOPTS_STATUSURL\fR
+.br
+URL to perform the http request when USEFULLSTATUS is enabled.
+(default: "http://localhost:80/")
 
 .IP \fBOPTS_VMSTAT\fR
 .br
 vmstat options
+(default: "-S M 1 3")
+
+.SH "REPORTING BUGS"
+Bugs and issues to be submitted via github
+<https://github.com/rackerlabs/recap/issues>.
 
 .SH AUTHOR
-The recap script is maintained by Brent Oswald (brent.oswald@rackspace.com) and Benjamin H. Graham (ben@administr8.me). If you have any questions, comments, or concerns, please let them know or post them to https://github.com/rackerlabs/recap/issues.
+The recap scripts are maintained by Rackspace, the list of contributors is available at https://github.com/rackerlabs/recap/blob/master/CHANGELOG.md#contributors.
 .SH "SEE ALSO"
 .BR recap (8),
 .BR recaplog (8),

--- a/src/recap.8
+++ b/src/recap.8
@@ -19,7 +19,7 @@
 .\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 .\" Boston, MA 02110-1301 USA.
 .\"
-.TH RECAP 8 "October 31, 2013"
+.TH RECAP 8 "July 7, 2017"
 .SH NAME
 recap \- dumps periodic information about running applications and resource usage
 .SH SYNOPSIS
@@ -27,24 +27,27 @@ recap \- dumps periodic information about running applications and resource usag
 .SH DESCRIPTION
 recap is a user-configurable script that can be run once, or run periodically out of cron to dump information about running processes and resource usage. It's useful on servers that have periodic, mysterious performance anomalies for tracking down what may be going on at the time of any particular incident.
 
-The default values for which reports are generated and how many reports are stored can be
+The values for which reports are generated and how many reports are stored can be overriden in
 .IR /etc/recap "."
 The output files from the script are written to
-.IR /var/log/recap "."
+.IR BASEDIR "."
 .TP
 \fB\-B\fR, \fB\-\-backup\fR
-This will perform a "backup". It will copy the latest log files from the last execution to "/var/log/recap/backups". The files will be identified by a timestamp in the name.
+This will perform a "backup". It will copy the latest log files from the last execution to the "backups" directory inside BASEDIR. The files will be identified by a timestamp in the name.
 .TP
 \fB\-S\fR, \fB\-\-snapshot\fR
-This will perform a "snapshot" report. It will generate a set of output files outside of the standard rotation. The files will be identified by a timestamp in the name.
+This will perform a "snapshot" report. It will generate a set of output files in the "snapshot" directory inside BASEDIR outside of the standard rotation. The files will be identified by a timestamp in the name.
 .TP
 .SH FILES
 .nf
 /etc/cron.d/recap
 /etc/recap
-.SH AUTHOR
-The recap script is maintained by Brent Oswald (brent.oswald@rackspace.com) and Benjamin H. Graham (ben@administr8.me). If you have any questions, comments, or concerns, please let them know or post them to https://github.com/rackerlabs/recap/issues.
+.SH "REPORTING BUGS"
+Bugs and issues to be submitted via github
+<https://github.com/rackerlabs/recap/issues>.
 
+.SH AUTHOR
+The recap scripts are maintained by Rackspace, the list of contributors is available at https://github.com/rackerlabs/recap/blob/master/CHANGELOG.md#contributors.
 .SH "SEE ALSO"
 .BR recap (5),
 .BR recaplog (8),

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -14,134 +14,187 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-#
-#   Package name:   recap
-#   Author:         Jacob Walcik
-#                   Carl Thompson
-#                   David King
-#
-#   Maintainer:     Brent Oswald
-#                   Benjamin Graham
-#                   Simone Soldateschi
-#
-#   Homepage:   https://github.com/rackerlabs/recap/
-#
 
-# If this variable is defined, the reports will be emailed the address
-# specified in addition to being written to the file system
-MAILTO=
+### settings shared by recap scripts
 
-############
-# RECAPLOG #
-############
-# compress old log files
-LOG_COMPRESS=1
-# Log files will be deleted after LOG_EXPIRY days
-LOG_EXPIRY=15
-# should recap send email in case of problems?
-EMAIL_ON_ERROR=1
-# recipients in case of problems
-EMAIL_ON_ERROR_RECIPIENTS="root@localhost"
-# email subject in case of problems
-EMAIL_ON_ERROR_SUBJECT="recaplog error"
+# BASEDIR - Directory where the logs are saved.
+# Example, to log in a different location: BASEDIR="/opt/recap"
+#BASEDIR="/var/log/recap"
 
-###########
-# REPORTS #
-###########
+# BACKUP_ITEMS - Is the list of reports generated and used by recap scripts
+# Example, just enable network stats: BACKUP_ITEMS="netstat"
+#BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
 
-# PS REPORT
-# Adds the output of "ps auxww" to a file named ps.log (default: yes)
-USEPS=yes
+### settings used only by recaplog
 
-# RESOURCES REPORT
-# This will create a resources.log file with the output of uptime, free, vmstat, and a few other pieces. (default: yes)
-USERESOURCES=yes
-# The following reports all require USERESOURCES to be set to "yes".
-# The following variables can be set to yes or no to enable or disable
-# specific optional output
-# Use "sar"
-USESAR=no
-# Use "sar -r"
-USESARR=no
-# Use "sar -q"
-USESARQ=no
-# Use "service httpd fullstatus"
-# Please ensure that the Apache is configured to allow access to the
-# http://localhost/server-status URL before enabling this option
-USEFULLSTATUS=yes
+# LOG_COMPRESS - Enable or disable log compression.
+# Example, to disable: LOG_COMPRESS=0
+#LOG_COMPRESS=1
 
-# Optional pstree output
-# Use "pstree". This will create a pstree.log file. (default: no)
-USEPSTREE=no
+# LOG_EXPIRY - Log files will be deleted after LOG_EXPIRY days
+# Example: LOG_EXPIRY=30
+#LOG_EXPIRY=15
 
-# NETSTAT REPORT
-# Use "netstat -ntulpae" output. This is required in order to use any of the other netstat output options.
-# This will create a netstat.log file. (default: no)
-USENETSTAT=yes
-# Use "netstat -s" output (requires USENETSTAT to be set to "yes")
-USENETSTATSUM=no
 
-# MYSQL REPORT
-# Use "mysqladmin status" output. This is required in order to use any of the other MySQL output options.
-# This will create a mysql.log file. Please ensure that the root user's .my.cnf is configured with appropriate
-# credentials before enabling this option. One way to test this is to run "mysql" in a root shell and see if
-# you get a "mysql> " prompt. (default: yes)
-USEMYSQL=yes
-# Use "mysqladmin processlist" output.
-USEMYSQLPROCESSLIST=yes
-# Provide information on InnoDB (default: no)
-USEINNODB=no
-# List custom .my.cnf path, default is /root/.my.cnf
-DOTMYDOTCNF=/root/.my.cnf
-# display mysql process list in a 'table' or 'vertical'
-MYSQL_PROCESS_LIST=table
+### settings used only by recap
 
-# DF REPORT
-# Use "df -h" output. This will show you a trend of disk space available on the drives. (default: yes)
-USEDF=yes
+# MAILTO - Send a report to the email defined.
+# Example: MAILTO="user@example.com"
+#MAILTO=""
 
-# SLABTOP REPORT
-# Use printf "name\tactive\tnum_obj\tobj_size\thuh\n"; tail -n+2 /proc/slabinfo | awk 'size=$3*$4 {print $1"\t"$2"\t"$3"\t"$4"\t"size/1048576}' | sort -k5gr output. This will show you more information on the slab table. (default: no)
-USESLAB=no
+# Minimum free space (in MB) required in ${BASEDIR} to run recap
+# Example, ensure there are at least 5MB: MIN_FREE_SPACE=5
+#MIN_FREE_SPACE=0
 
-# MMon REPORT
-# Common Managed Monitoring commands such as the following:
-# tail /var/log/httpd/error_log
-# history
-# service httpd status
-# netstat -antp | awk '$4 ~ /:80$/ {c++;print $5|"cut -f1 -d:|sort |uniq -c|sort -rn |head -10"} END {print c" Total Connections to port 80"}'
-# tail /var/log/httpd/error_log
-# tail /var/log/messages
-# tail /var/log/mysqld.log
-# tail /var/log/maillog
-# tail /usr/local/psa/var/log/maillog
-# tail /var/log/secure
-# grep Failed /var/log/secure | sed -e "s/^.*from //g" | sed -e "s/ port.*$//g" | sort -n | uniq -c | sort -nr | head -20
-# pstree -G
-# df -h
+# Maximum load allowed to run recap, abort if load is higher than this value
+# Example, don't run recap if server load is above 4: MAXLOAD=4
+#MAXLOAD=10
 
-# FDISK REPORT
-USEFDISK=no
 
-# backup items
-BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
+### recap Reports
 
-# minimum free disk space in Megabytes
-MIN_FREE_SPACE=0
+## Report: fdisk
+# USEFDISK - Generage logs from "fdisk ${OPTS_FDISK}"
+# Options can be modified in OPTS_FDISK
+# Example, to enable: USEFDISK=yes
+#USEFDISK=no
 
-# max load - abort if load is higher than this value
-#MAXLOAD=1000
+## Report: mysql
+# USEMYSQL - Generates logs from "mysqladmin status"
+# makes use of DOTMYDOTCNF.
+# required by: USEMYSQLPROCESSLIST, USEINNODB
+# Example, to enable: USEMYSQL=yes
+#USEMYSQL=no
 
-###########################
-# DEFAULT COMMAND OPTIONS #
-###########################
-OPTS_DF="-x nfs"
-OPTS_FDISK="-l"
-OPTS_FREE=""
-OPTS_IOSTAT="-t -x 1 3"
-OPTS_IOTOP="-b -o -t -n 3"
-OPTS_NETSTAT="-ntulpae"
-OPTS_NETSTAT_SUM="-s"
-OPTS_PS="auxfww"
-OPTS_PSTREE=""
-OPTS_VMSTAT="-S M 1 3"
+# USEMYSQLPROCESSLIST - Generates logs from "mysqladmin processlist"
+# Makes use of DOTMYDOTCNF and MYSQL_PROCESS_LIST
+# requires: USEMYSQL
+# Example, to enable: USEMYSQLPROCESSLIST=yes
+#USEMYSQLPROCESSLIST=no
+
+# USEINNODB - Generates logs from "mysql show engine innodb status"
+# Makes use of DOTMYDOTCNF
+# requires: USEMYSQL
+# Example, to enable: USEINNODB=yes
+#USEINNODB=no
+
+## Report: netstat
+# USENETSTAT - Generates network stats from "netstat ${OPTS_NETSTAT}"
+# required by: USENETSTATSUM
+# Example, to disable: USENETSTATSUM=no
+#USENETSTAT=yes
+
+# USENETSTATSUM - Generates logs from "netstat ${OPTS_NETSTAT_SUM}".
+# requires: USENETSTAT
+# Example, to enable: USENETSTATSUM=yes
+#USENETSTATSUM=no
+
+## Report: ps
+# USEPS - Generates logs from "ps"
+# Options can be modified in OTPS_PS
+# Example, to disable: USEPS=no
+#USEPS=yes
+
+## Report: pstree
+# USEPSTREE - Generates logs from pstree
+# Options can be modified in OTPS_PSTREE
+# Example, to enable: USEPSTREE=yes
+#USEPSTREE=no
+
+## Report: resources
+# USERESOURCES - Generates "resources"(uptime, free, vmstat, iostat, iotop) log
+# required by: USEDF, USESLAB, USESAR, USESARQ, USESARR, USEFULLSTATUS
+# Example, to disable: USERESOURCES=no
+#USERESOURCES=yes
+
+# USEDF - Generates logs from df
+# requires: USERESOURCES
+# Options can be modified in OPTS_DF
+# Example, to disable: USEDF=no
+#USEDF=yes
+
+# USESLAB - Generates logs from the slab table.
+# requires: USERESOURCES
+# Example, to enable: USESLAB=yes
+#USESLAB=no
+
+# USERSAR - Generates logs from sar.
+# requires: USERESOURCES
+# Example, to disable: USESAR=no
+#USESAR=yes
+
+# USESARQ - Generates logs from "sar -q" (logs queue lenght, load data)
+# requires: USERESOURCES
+# Example, to enable: USESARQ=yes
+#USESARQ=no
+
+# USESARR - Generates logs from"sar -r" (logs memory data)
+# requires: USERESOURCES
+# Example, to enable: USESARR=yes
+#USESARR=no
+
+# USEFULLSTATUS - Performs an http request(GET) to the URL defined in
+# OPTS_STATUSURL. Needs a webserver configured to respond to this request.
+# Nginx(nginx_status) and Apache HTTPD(server-stats) offer this functionality
+# that needs to be enabled.
+# requires: USERESOURCES
+# Example, to enable: USEFULLSTATUS=yes
+#USEFULLSTATUS=no
+
+### Options used by the tools generating the reports
+
+# required by: USEMYSQL, USEMYSQLPROCESSLIST, USEINNODB
+# Example: DOTMYDOTCNF="/root/.my_alternative.cnf"
+#DOTMYDOTCNF="/root/.my.cnf"
+
+# required by: USEMYSQLPROCESSLIST
+# Example, generate vertical output: MYSQL_PROCESS_LIST=vertical
+#MYSQL_PROCESS_LIST=table
+
+# required by: USEDF
+# Example: OPTS_DF='-PhT -x nfs'
+#OPTS_DF="-x nfs"
+
+# required by: USEFDISK
+# Example: OPTS_FDISK="-o gpt -l"
+#OPTS_FDISK="-l"
+
+# required by: USEFREE
+# Example: OPTS_FREE='-lwt'
+#OPTS_FREE=""
+
+# required by: USERESOURCES
+# used by "iostat"
+# Example: OPTS_IOSTAT="-Ntx 3 3"
+#OPTS_IOSTAT="-t -x 1 3"
+
+# required by: USERESOURCES
+# used by "iotop"
+# Example: OPTS_IOTOP="-botqn3 -d3"
+#OPTS_IOTOP="-b -o -t -n 3"
+
+# required by: USENETSTAT
+# Example: OPTS_NETSTAT="-punteCola"
+#OPTS_NETSTAT="-ntulpae"
+
+# required by: USENETSTATSUM
+# Example: OPTS_NETSTAT_SUM="-stuUSw"
+#OPTS_NETSTAT_SUM="-s"
+
+# required by: USEPS
+# Example: OPTS_PS="-Laef"
+#OPTS_PS="auxfww"
+
+# required by: USEPSTREE
+# Example: OPTS_PSTREE="-cApu"
+#OPTS_PSTREE="-p"
+
+# required by: USEFULLSTATUS
+# Example: OPTS_STATUSURL=http://localhost/nginx_status
+#OPTS_STATUSURL=http://localhost:80/
+
+# required by: USERESOURCES
+# used by "vmstat"
+# Example: OPTS_VMSTAT="-aSM 3 3"
+#OPTS_VMSTAT="-S M 1 3"
+

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -56,90 +56,90 @@
 ## Report: fdisk
 # USEFDISK - Generage logs from "fdisk ${OPTS_FDISK}"
 # Options can be modified in OPTS_FDISK
-# Example, to enable: USEFDISK=yes
-#USEFDISK=no
+# Example, to enable: USEFDISK="yes"
+#USEFDISK="no"
 
 ## Report: mysql
 # USEMYSQL - Generates logs from "mysqladmin status"
 # makes use of DOTMYDOTCNF.
 # required by: USEMYSQLPROCESSLIST, USEINNODB
-# Example, to enable: USEMYSQL=yes
-#USEMYSQL=no
+# Example, to enable: USEMYSQL="yes"
+#USEMYSQL="no"
 
 # USEMYSQLPROCESSLIST - Generates logs from "mysqladmin processlist"
 # Makes use of DOTMYDOTCNF and MYSQL_PROCESS_LIST
 # requires: USEMYSQL
-# Example, to enable: USEMYSQLPROCESSLIST=yes
-#USEMYSQLPROCESSLIST=no
+# Example, to enable: USEMYSQLPROCESSLIST="yes"
+#USEMYSQLPROCESSLIST="no"
 
 # USEINNODB - Generates logs from "mysql show engine innodb status"
 # Makes use of DOTMYDOTCNF
 # requires: USEMYSQL
-# Example, to enable: USEINNODB=yes
-#USEINNODB=no
+# Example, to enable: USEINNODB="yes"
+#USEINNODB="no"
 
 ## Report: netstat
 # USENETSTAT - Generates network stats from "netstat ${OPTS_NETSTAT}"
 # required by: USENETSTATSUM
-# Example, to disable: USENETSTATSUM=no
-#USENETSTAT=yes
+# Example, to disable: USENETSTATSUM="no"
+#USENETSTAT="yes"
 
 # USENETSTATSUM - Generates logs from "netstat ${OPTS_NETSTAT_SUM}".
 # requires: USENETSTAT
-# Example, to enable: USENETSTATSUM=yes
-#USENETSTATSUM=no
+# Example, to enable: USENETSTATSUM="yes"
+#USENETSTATSUM="no"
 
 ## Report: ps
 # USEPS - Generates logs from "ps"
 # Options can be modified in OTPS_PS
-# Example, to disable: USEPS=no
-#USEPS=yes
+# Example, to disable: USEPS="no"
+#USEPS="yes"
 
 ## Report: pstree
 # USEPSTREE - Generates logs from pstree
 # Options can be modified in OTPS_PSTREE
-# Example, to enable: USEPSTREE=yes
-#USEPSTREE=no
+# Example, to enable: USEPSTREE="yes"
+#USEPSTREE="no"
 
 ## Report: resources
 # USERESOURCES - Generates "resources"(uptime, free, vmstat, iostat, iotop) log
 # required by: USEDF, USESLAB, USESAR, USESARQ, USESARR, USEFULLSTATUS
-# Example, to disable: USERESOURCES=no
-#USERESOURCES=yes
+# Example, to disable: USERESOURCES="no"
+#USERESOURCES="yes"
 
 # USEDF - Generates logs from df
 # requires: USERESOURCES
 # Options can be modified in OPTS_DF
-# Example, to disable: USEDF=no
-#USEDF=yes
+# Example, to disable: USEDF="no"
+#USEDF="yes"
 
 # USESLAB - Generates logs from the slab table.
 # requires: USERESOURCES
-# Example, to enable: USESLAB=yes
-#USESLAB=no
+# Example, to enable: USESLAB="yes"
+#USESLAB="no"
 
 # USERSAR - Generates logs from sar.
 # requires: USERESOURCES
-# Example, to disable: USESAR=no
-#USESAR=yes
+# Example, to disable: USESAR="no"
+#USESAR="yes"
 
 # USESARQ - Generates logs from "sar -q" (logs queue lenght, load data)
 # requires: USERESOURCES
-# Example, to enable: USESARQ=yes
-#USESARQ=no
+# Example, to enable: USESARQ="yes"
+#USESARQ="no"
 
 # USESARR - Generates logs from"sar -r" (logs memory data)
 # requires: USERESOURCES
-# Example, to enable: USESARR=yes
-#USESARR=no
+# Example, to enable: USESARR="yes"
+#USESARR="no"
 
 # USEFULLSTATUS - Performs an http request(GET) to the URL defined in
 # OPTS_STATUSURL. Needs a webserver configured to respond to this request.
 # Nginx(nginx_status) and Apache HTTPD(server-stats) offer this functionality
 # that needs to be enabled.
 # requires: USERESOURCES
-# Example, to enable: USEFULLSTATUS=yes
-#USEFULLSTATUS=no
+# Example, to enable: USEFULLSTATUS="yes"
+#USEFULLSTATUS="no"
 
 ### Options used by the tools generating the reports
 
@@ -148,11 +148,15 @@
 #DOTMYDOTCNF="/root/.my.cnf"
 
 # required by: USEMYSQLPROCESSLIST
-# Example, generate vertical output: MYSQL_PROCESS_LIST=vertical
-#MYSQL_PROCESS_LIST=table
+# Example, generate vertical output: MYSQL_PROCESS_LIST="vertical"
+#MYSQL_PROCESS_LIST="table"
+
+# required by: USEFULLSTATUS
+# Example: OPTS_CURL="-skLv"
+#OPTS_CURL="-Ls"
 
 # required by: USEDF
-# Example: OPTS_DF='-PhT -x nfs'
+# Example: OPTS_DF="-PhT -x nfs"
 #OPTS_DF="-x nfs"
 
 # required by: USEFDISK
@@ -160,7 +164,7 @@
 #OPTS_FDISK="-l"
 
 # required by: USEFREE
-# Example: OPTS_FREE='-lwt'
+# Example: OPTS_FREE="-lwt"
 #OPTS_FREE=""
 
 # required by: USERESOURCES
@@ -190,8 +194,8 @@
 #OPTS_PSTREE="-p"
 
 # required by: USEFULLSTATUS
-# Example: OPTS_STATUSURL=http://localhost/nginx_status
-#OPTS_STATUSURL=http://localhost:80/
+# Example: OPTS_STATUSURL="http://localhost/nginx_status"
+#OPTS_STATUSURL="http://localhost:80/"
 
 # required by: USERESOURCES
 # used by "vmstat"

--- a/src/recaplog
+++ b/src/recaplog
@@ -43,21 +43,17 @@
 #~
 #~ recaplog will not produce output if no tty is found, this is useful when
 #~ running from cron.
+#~
 
-
-## DEFAULT CONFIG ##
+## Default settings
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 BASEDIR="/var/log/recap"
 LOCKFILE="/var/lock/recaplog.lock"
 LOG_COMPRESS=1
-LOG_EXPIRY=0
+LOG_EXPIRY=15
 BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
 LOGFILE="${BASEDIR}/recaplog.log"
-EMAIL_ON_ERROR=1
-EMAIL_ON_ERROR_SUBJECT="recaplog error"
-EMAIL_ON_ERROR_RECIPIENTS="root@localhost"
 
-## FUNCTIONS ##
 
 # Function to generate timestamps
 ts() {

--- a/src/recaplog.8
+++ b/src/recaplog.8
@@ -19,7 +19,7 @@
 .\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 .\" Boston, MA 02110-1301 USA.
 .\"
-.TH "RECAPLOG" "8" "January 21, 2017"
+.TH "RECAPLOG" "8" "July 7, 2017"
 
 .SH NAME
 .PP
@@ -44,7 +44,18 @@ recaplog is a user-configurable script that runs periodically out of cron to com
 .BI "-v"
 .R Prints to stdout.
 
+.SH SETTINGS
+These can be modified via the config file.
 .TP
+.BI LOG_COMPRESS
+.R Enables(1) or disables(0) log compression.
+.B (default: 1)
+
+.TP
+.BI LOG_EXPIRY
+.R Number of days held for the logs.
+.B (default: 15)
+
 .SH FILES
 .nf
 /etc/recap \- The configuration file.
@@ -56,7 +67,7 @@ Bugs and issues to be submitted via github
 <https://github.com/rackerlabs/recap/issues>.
 
 .SH AUTHOR
-The recaplog script was initially created by Simone Soldateschi(https://github.com/siso).
+The recap scripts are maintained by Rackspace, the list of contributors is available at https://github.com/rackerlabs/recap/blob/master/CHANGELOG.md#contributors.
 
 .SH "SEE ALSO"
 .BR recap (5),

--- a/src/recaptool
+++ b/src/recaptool
@@ -16,15 +16,22 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+## Default settings
 ME=`basename $0`
-RECAPPATH="/var/log/recap"
+BASEDIR="/var/log/recap"
 cmds=""
+CONFFILE="/etc/recap"
+
+## Overriding defaults
+if [[ -r "${CONFFILE}" ]]; then
+  source "${CONFFILE}"
+fi
 
 memproc() {
 	PROCESS="$1"
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/ps_*.log`; do
+	for i in `ls "${BASEDIR}"/ps_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		egrep "$PROCESS" $i -c | tr "\n" "\t" >> $TMP
 		egrep "$PROCESS" $i | awk '{ SUM += $6 } END {print SUM/1024, "M"};' >> $TMP
@@ -37,7 +44,7 @@ proc() {
 	PROCESS="$1"
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/ps_*.log`; do
+	for i in `ls "${BASEDIR}"/ps_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		egrep "$PROCESS" $i -c >> $TMP
 	done
@@ -49,7 +56,7 @@ mem() {
 	PROCESS="$1"
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/ps_*.log`; do
+	for i in `ls "${BASEDIR}"/ps_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		egrep "$PROCESS" $i | awk '{ SUM += $6 } END {print SUM/1024, "M"};' >> $TMP
 	done
@@ -61,7 +68,7 @@ net() {
 	PORT="$1"
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/netstat_*.log`; do
+	for i in `ls "${BASEDIR}"/netstat_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		egrep ":$PORT " $i -c >> $TMP
 	done
@@ -73,7 +80,7 @@ netestab() {
 	PORT="$1"
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/netstat_*.log`; do
+	for i in `ls "${BASEDIR}"/netstat_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		egrep ":$PORT .*ESTAB" $i -c >> $TMP
 	done
@@ -84,7 +91,7 @@ netestab() {
 querycount() {
 	TMP=`mktemp`
 	>$TMP
-	for i in `ls "${RECAPPATH}"/mysql_*.log`; do
+	for i in `ls "${BASEDIR}"/mysql_*.log`; do
 		head -n 1 $i | tr "\n" "\t" >> $TMP
 		grep "Query" -c $i >> $TMP
 	done
@@ -117,7 +124,7 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 		-d)
 			if [ -d $2 ]; then
-				RECAPPATH=$2
+				BASEDIR=$2
 				shift 2
 			else
 				echo "Error: $2 is not a valid directory."
@@ -141,7 +148,7 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
-echo "Information: Using ${RECAPPATH} as recap log path"
+echo "Information: Using ${BASEDIR} as recap log path"
 echo "Information: Executing $cmds"
 
 $cmds

--- a/src/recaptool.8
+++ b/src/recaptool.8
@@ -19,7 +19,7 @@
 .\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 .\" Boston, MA 02110-1301 USA.
 .\"
-.TH "RECAPTOOL" "8" "October 3, 2016"
+.TH "RECAPTOOL" "8" "July 7, 2017"
 
 
 .SH NAME
@@ -73,8 +73,9 @@ a particular option in the logs.
 
 .TP
 .BI "-d " "PATH" 
-.RB "Specify the recap log " "PATH" ". Default is"
+.RB "Overrides the recap log " "PATH" ". Default uses BASEDIR"
 .I /var/log/recap/
+.RB "Can be changed in config file."
 
 .SH FILES
 .I /var/log/recap/*.log
@@ -118,8 +119,7 @@ Bugs and issues to be submitted via github
 <https://github.com/rackerlabs/recap/issues>.
 
 .SH AUTHOR
-The recaptool script was initially created by "Benjamin H. Graham"
-<ben@administr8.me>.
+The recap scripts are maintained by Rackspace, the list of contributors is available at https://github.com/rackerlabs/recap/blob/master/CHANGELOG.md#contributors.
 
 .SH "SEE ALSO"
 .BR recap (5),


### PR DESCRIPTION
## Notes of changes performed

### tl;dr

- EMAIL_ON_ERROR, EMAIL_ON_ERROR_SUBJECT, EMAIL_ON_ERROR_RECIPIENTS - removed(not used)
- MAXLOAD - 10*cpu(dynamic by default, was 1000)
- LOG_EXPIRY - default 15(by default was 0, but set to 15 in the recap conf)
- ROTATE, ROTATELOGS - removed(not used)
- USEDF - default is now enabled(by default was disabled, but enabled in the recap conf)
- USEFULLSTATUS - Functionality reimplemented to avoid being tied to a web browser.
- USEMYSQL - disabled(by default was disabled, but enabled in the recap conf)
- USEMYSQLPROCESSLIST - disabled(by default was disabled, but enabled in the recap conf)
- USENETSTAT - default is enabled(by default was disabled, but enabled in the recap conf)
- USESAR - default is enabled(by default was disabled)
- OPTS_PSTREE - default is "-p"(by default was empty '')
- OPTS_STATUSURL - default is "http://localhost:80/"(this is a new option used by USEFULLSTATUS)

- Snapshots file name now matches regular logs and backups.

---
**Detailed notes of changes**
---

### Options used by the recap scripts
- BACKUP_ITEMS - Used by recap and recaplog(default: "fdisk mysql netstat ps pstree resources"). fixed in recap.conf, added to man. See NOTE 1.
- BASEDIR - used in recap and recaplog(default: "/var/log/recap"). was not defined as a setting that can be overriden, has been added to recap.c\
onf, added to man.
- EMAIL_ON_ERROR, EMAIL_ON_ERROR_SUBJECT, EMAIL_ON_ERROR_RECIPIENTS - not used, have been removed.
- LOG_COMPRESS - used in recaplog(default: 1), fixed in recap.conf, added to recaplog.8
- LOG_EXPIRY - used in recaplog(OLD default:0, NEW default: 15), fixed in recap.conf, added to recaplog.8
- MAILTO - used in recap(default: ""). fixed in recap.conf.
- MAXLOAD - used in recap(old default: "1000", new default is dynamic 10 times the number of the CPUs identified by the kernel). fixed in recap.\
conf, added to man.
- MIN_FREE_SPACE - used in recap(default: 0). fixed in recap.conf, added to man. (Minimal required space in MB)
- ROTATE - This setting is not in use any longer, has been removed from all the places where it was referenced.
- ROTATELOGS - Same as above this was not in use and has been removed.
### Reports
- USEDF - used in recap(OLD default: no, NEW default: yes). fixed in recap.conf, added to man.
- USEFDISK - used in recap(default: no). fixed in recap.conf, added to man.
- USEFULLSTATUS - used in recap(default: no). fixed in recap.conf, updated man page. NOTE: Reimplemented the functionality to avoid apache httpd\
 specific, now depends on curl instead of httpd/apache.
- USEINNODB - used in recap(default: no). fixed in recap.conf, added to man.
- USEMYSQL - used in recap(default: no). fixed in recap.conf, man updated. NOTE: This was enabled in the config previously.
- USEMYSQLPROCESSLIST - used in recap(default: no). fixed in recap.conf, man updated. NOTE: This was enabled in the config previously.
- USENETSTAT - used in recap(OLD default: no, NEW default: yes). fixed in recap.conf, changed in recap, man updated.
- USENETSTATSUM - used in recap(default: no). fixed in recap.conf, man updated.
- USEPS - used in recap(default: yes). fixed in recap.conf.
- USEPSTREE - used in recap(default: no). fixed in recap.conf, man updated.
- USERESOURCES - used in recap(default: yes). includes at leasts: uptime, free, vmstat, iostat, iotop, additional resources are included if enab\
led. fixed in recap.conf
- USESAR - used in recap(OLD default: no, NEW default: yes). fixed in recap.conf. People has requested this to be turned on("yes") by default, m\
an has been updated to reflect this. sysstat is already a depencency in the .spec file.
- USESARQ - used in recap(default: no). takes care of queue lenght(load) data (sar -q). recap.conf sets it to no as well, needs to be commented \
out in recap.conf.
- USESARR - used in recap(default: no). takes care of memory data (sar -r). recap.conf sets it to no as well, needs to be removed from recap.con\
f.
- USESLAB - used in recap(default: no). fixed in recap.conf, added to man.

### Command line Options used by the tools generating the reports

- DOTMYDOTCNF - used in recap(default: /root/.my.cnf). fixed in recap.conf, added to man.
- MYSQL_PROCESS_LIST - used in recap(default: table). fixed in recap.conf, added to man.
- OPTS_DF - used in recap(default: "-x nfs"). fixed in recap.conf.
- OPTS_FDISK - used in recap(default: "-l"). fixed in recap.conf, see NOTE 2.
- OPTS_FREE - used in recap(default: ""). fixed in recap.conf.
- OPTS_IOSTAT - used in recap(default: "-t -x 1 3"). fixed in recap.conf.
- OPTS_IOTOP - used ony by recap(default: "-b -o -t -n 3") fixed in recap.
- OPTS_NETSTAT - used in recap(default: "-ntulpae"). fixed in recap.conf.
- OPTS_NETSTAT_SUM - used in recap(default: "-s"). fixed in recap.conf.
- OPTS_PS - only used by recap(default: "auxfww"). fixed in recap.conf
- OPTS_PSTREE - used in recap(OLD default: "", NEW default: "-p"). Adding "-p" to include PID, fixed in recap.conf. updated in man.
- OPTS_STATUSURL - new variable used to avoid the use of apachectl, this is the URL that needs to be checked for the full status, default is "ht\
tp://localhost:80/", added to man.
- OPTS_VMSTAT - used in recap(default: "-S M 1 3"). fixed in recap.conf, updated in man.

### Notes

1. BACKUP_ITEMS either will have to be created dynamically from the options enabled, e.g. USE___ or the USE__ will be enabled from the BACKUP_IT\
EMS.  IF one or the other is missing/disabled there will be inconsistencies. This is a TODO item(needs an issue created for this), that will be \
addressed in another PR.

2. FDISK needs love, needs to be more dynamic and use parted/fdisk, but this limits the options, it will have to be only "-l". This isa TODO ite\
m(needs an issue created for this), this is a feature.

### Other variables

#### recap
- LOG_SUFFIX=$(date +%Y%m%d-%H%M%S)
- PATH=/bin:/usr/bin:/sbin:/usr/sbin
- DATE=`date +%Y-%m-%d_%H:%M:%S` ## In the snapshot functionality, this provides inconsistencies with LOG_SUFFIX, removing and using LOG_SUFFIX \
instead.
- SNAPSHOT="no"
- BACKUP="no"
- LOCKFILE="/var/lock/recap.lock"
- BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
- MAXLOAD="1000"
- OUTPUTDIR_MODE="750"

#### recaplog
- PATH=/bin:/usr/bin:/sbin:/usr/sbin
- LOCKFILE="/var/lock/recaplog.lock"
- LOG_COMPRESS=1
- LOG_EXPIRY=0
- BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
- LOGFILE="${BASEDIR}/recaplog.log"
- ## These needs to be removed as recaplog does not send email anymore
- MAIL_ON_ERROR=1
- EMAIL_ON_ERROR_SUBJECT="recaplog error"
- EMAIL_ON_ERROR_RECIPIENTS="root@localhost"

### Setting Dependencies:

- USERESOURCES
  - USEDF
  - USESAR
  - USESARQ
  - USESARR
  - USEFULLSTATUS

- USENETSTAT
  - USENETSTATSUM

- USEMYSQL
  - USEMYSQLPROCESSLIST
  - USEINNODB
  - DOTMYDOTCNF
  - MYSQL_PROCESS_LIST

### Other changes
1. STATUSURL - This was introduced to be more generic with USEFULLSTATUS, this will allow to query any webserver that supports status(httpd, ngi\
nx)
1. Snapshots file name matches regular logs and backups, example of the differences:

```bash
## Regular format on recap
# ls -ltr /var/log/recap/ | tail -4
-rw-r--r--. 1 root root    820 Jun  9 14:30 pstree_20170609-143001.log
-rw-r--r--. 1 root root   6314 Jun  9 14:30 netstat_20170609-143001.log
-rw-r--r--. 1 root root    297 Jun  9 14:30 fdisk_20170609-143001.log
-rw-r--r--. 1 root root   5127 Jun  9 14:30 mysql_20170609-143001.log

## Backups use the same log formatting as recap regular logs:
# ls -ltr /var/log/recap/backups | tail -4
-rw-r--r--. 1 root root 6191 Jun  9 14:27 netstat_20170609-142001.log
-rw-r--r--. 1 root root 8070 Jun  9 14:27 ps_20170609-142001.log
-rw-r--r--. 1 root root  785 Jun  9 14:27 pstree_20170609-142001.log
-rw-r--r--. 1 root root 8407 Jun  9 14:27 resources_20170609-142001.log

## Snapshots uses a completely different formatting:
# ls -ltr /var/log/recap/snapshots/ | tail -4
-rw-r--r--. 1 root root  812 Jun  9 14:27 pstree.log_snapshot_2017-06-09_14:27:43
-rw-r--r--. 1 root root 6314 Jun  9 14:27 netstat.log_snapshot_2017-06-09_14:27:43
-rw-r--r--. 1 root root  297 Jun  9 14:27 fdisk.log_snapshot_2017-06-09_14:27:43
-rw-r--r--. 1 root root 5127 Jun  9 14:27 mysql.log_snapshot_2017-06-09_14:27:43
```

Now uses:
```bash
# ls -ltr /var/log/recap/snapshots/ | tail -4
-rw-r--r--. 1 root root  899 Jun  9 14:40 pstree_20170609-144025.log_snapshot
-rw-r--r--. 1 root root 6437 Jun  9 14:40 netstat_20170609-144025.log_snapshot
-rw-r--r--. 1 root root  297 Jun  9 14:40 fdisk_20170609-144025.log_snapshot
-rw-r--r--. 1 root root 5127 Jun  9 14:40 mysql_20170609-144025.log_snapshot
```

1. recaptool now makes use of BASEDIR to align with recap and recaplog.

---

Fix #94 