### PR TITLE
Correcting exit codes when trapping signals.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -102,7 +102,6 @@ OPTS_STATUSURL="http://localhost:80/"
 # Cleanup function to remove lock
 cleanup() {
   rm -f "${LOCKFILE}"
-  exit 2
 }
 
 # Create a Lock so that recap does not try to run over itself.
@@ -112,7 +111,8 @@ recaplock() {
     echo "ERROR $( basename $0 ) ($$): Lock File exists - exiting"
     exit 1
   else
-    trap 'cleanup' 1 2 15 17 19 23 EXIT
+    trap 'cleanup; exit 2' 1 2 15 17 19 23
+    trap 'cleanup' EXIT
   fi
 }
 
@@ -691,4 +691,4 @@ if [[ -n "${MAILTO}" ]]; then
 fi
 
 # We're done, time to exit
-exit
+exit 0

--- a/src/recaplog
+++ b/src/recaplog
@@ -219,9 +219,8 @@ pack_old_logs() {
 
 # Cleanup function to remove lock
 cleanup() {
-  log INFO "$( basename $0 ) ($$): Caught exit signal - deleting ${LOCKFILE}"
+  log INFO "$( basename $0 ) ($$): Caught signal - deleting ${LOCKFILE}"
   rm -f "${LOCKFILE}"
-  exit 2
 }
 
 # Create a Lock so that recaplog does not try to run over itself.
@@ -231,7 +230,8 @@ recaploglock() {
     log ERROR "$( basename $0 ) ($$): Lock File exists - exiting"
     exit 1
   else
-    trap 'cleanup' 1 2 15 17 19 23 EXIT
+    trap 'cleanup; exit 2' 1 2 15 17 19 23
+    trap 'cleanup' EXIT
     log INFO "$( basename $0 ) ($$): Created lock file: ${LOCKFILE}"
   fi
 }


### PR DESCRIPTION
This commit takes care of moving the exit code to the appropriate trapped signals
HUP(1), INT(2), 15(TERM), 19(STOP), 23(URG) will now produce correctly exit code 2.  While a clean EXIT(0 under trap) will be returned in normal conditions.  In both situations the lock file is removed.  This applies to both `recap` and `recaplog` scripts.

Some of the testing to show the right behaviour:

* recap
```bash
## Sending TERM(15) signal to the PID
# recap; echo $?
2

## INTerrupting the process
# recap
^C
# echo $?
2

## Allowing normal operation to the process
# recap; echo $?
0

### Snapshots

## Sending TERM(15) signal to the PID on snapshots
# recap --snapshot; echo $?
2

## INTerrupting the process
# recap --snapshot
^C
# echo $?
2

## Allowing normal operation to the process
# recap --snapshot; echo $?
0

###  Backups is not an issue as it does not implement locking at the moment.

```

* recaplog
```bash
## Sending TERM(15) signal to the PID
# recaplog >/dev/null; echo $?
2

## INTerrupting the process
# recaplog >/dev/null
^C
# echo $?
2

## Allowing normal operation to the process
# recaplog >/dev/null; echo $?
0
```

Fix #103 