### PR TITLE
Deprecating netstat in favor of ~modern~ current tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ These are the type of reports generated and their dependencies.
 
 ##### netstat
 
-- **USENETSTAT** - Generates network stats from "netstat `${OPTS_NETSTAT}`"
+- **USENETSTAT** - Generates network stats from "ss `${OPTS_NETSTAT}`"
 
   Required by: `USENETSTATSUM`
 
   Default: `USENETSTAT="yes"`
 
 
-- **USENETSTATSUM** - Generates logs from "netstat `${OPTS_NETSTAT_SUM}`".
+- **USENETSTATSUM** - Generates logs from "nstat `${OPTS_NETSTAT_SUM}`".
 
   Requires: `USENETSTAT`
 
@@ -291,17 +291,17 @@ Options used by the tools generating the reports
 
   Default: `OPTS_IOTOP="-b -o -t -n 3"`
 
-- **OPTS_NETSTAT** - netstat options
+- **OPTS_NETSTAT** - ss options
 
   Required by: `USENETSTAT`
 
-  Default: `OPTS_NETSTAT="-ntulpae"`
+  Default: `OPTS_NETSTAT="-atunp"`
 
-- **OPTS_NETSTAT_SUM** - netstat statistics options
+- **OPTS_NETSTAT_SUM** - nstat options
 
   Required by: `USENETSTATSUM`
 
-  Default: `OPTS_NETSTAT_SUM="-s"`
+  Default: `OPTS_NETSTAT_SUM="-a"`
 
 - **OPTS_PS** - ps options
 

--- a/src/recap
+++ b/src/recap
@@ -58,54 +58,89 @@ declare -r LOG_SUFFIX=$( date +%Y%m%d-%H%M%S )
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 ## Default settings(modified through command line arguments)
-BACKUP="no"
-SNAPSHOT="no"
+declare -r default_BACKUP="no"
+declare -r default_SNAPSHOT="no"
+BACKUP="${default_BACKUP}"
+SNAPSHOT="${default_SNAPSHOT}"
 
 ## Default settings(can be overridden in config file)
-BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
-BASEDIR="/var/log/recap"
-MAILTO=""
-MIN_FREE_SPACE=0
-USEFDISK="no"
-USEPS="yes"
-USEPSTREE="no"
-USESLAB="no"
+declare -r default_BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
+declare -r default_BASEDIR="/var/log/recap"
+declare -r default_MAILTO=""
+declare -r default_MIN_FREE_SPACE=0
+declare -r default_USEFDISK="no"
+declare -r default_USEPS="yes"
+declare -r default_USEPSTREE="no"
+declare -r default_USESLAB="no"
+BACKUP_ITEMS="${default_BACKUP_ITEMS}"
+BASEDIR="${default_BASEDIR}"
+MAILTO="${default_MAILTO}"
+MIN_FREE_SPACE=${default_MIN_FREE_SPACE}
+USEFDISK="${default_USEFDISK}"
+USEPS="${default_USEPS}"
+USEPSTREE="${default_USEPSTREE}"
+USESLAB="${default_USESLAB}"
 
 # Parent setting(other settings depend on this)
-USERESOURCES="yes"
+declare -r default_USERESOURCES="yes"
+USERESOURCES="${default_USERESOURCES}"
 # These depend on USERRESOURCES to be enabled("yes")
-USEDF="yes"
-USEFULLSTATUS="no"
-USESAR="yes"
-USESARQ="no"
-USESARR="no"
+declare -r default_USEDF="yes"
+declare -r default_USEFULLSTATUS="no"
+declare -r default_USESAR="yes"
+declare -r default_USESARQ="no"
+declare -r default_USESARR="no"
+USEDF="${default_USEDF}"
+USEFULLSTATUS="${default_USEFULLSTATUS}"
+USESAR="${default_USESAR}"
+USESARQ="${default_USESARQ}"
+USESARR="${default_USESARR}"
 
 # Parent setting(other settings depend on this)
-USENETSTAT="yes"
+declare -r default_USENETSTAT="yes"
+USENETSTAT="${default_USENETSTAT}"
 # These depend on USENETSTAT to be enabled("yes")
-USENETSTATSUM="no"
+declare -r default_USENETSTATSUM="no"
+USENETSTATSUM="${default_USENETSTATSUM}"
 
 # Parent setting(other settings depend on this)
-USEMYSQL="no"
+declare -r default_USEMYSQL="no"
+USEMYSQL="${default_USEMYSQL}"
 # These depend on USEMYSQL to be enabled("yes")
-DOTMYDOTCNF="/root/.my.cnf"
-MYSQL_PROCESS_LIST="table"
-USEINNODB="no"
-USEMYSQLPROCESSLIST="no"
+declare -r default_DOTMYDOTCNF="/root/.my.cnf"
+declare -r default_MYSQL_PROCESS_LIST="table"
+declare -r default_USEINNODB="no"
+declare -r default_USEMYSQLPROCESSLIST="no"
+DOTMYDOTCNF="${default_DOTMYDOTCNF}"
+MYSQL_PROCESS_LIST="${default_MYSQL_PROCESS_LIST}"
+USEINNODB="${default_USEINNODB}"
+USEMYSQLPROCESSLIST="${default_USEMYSQLPROCESSLIST}"
 
 # Default command options(can be overriden in config file)
-OPTS_LINKS="-dump"
-OPTS_DF="-x nfs"
-OPTS_FDISK="-l"
-OPTS_FREE=""
-OPTS_IOSTAT="-t -x 1 3"
-OPTS_IOTOP="-b -o -t -n 3"
-OPTS_NETSTAT="-atunp"
-OPTS_NETSTAT_SUM="-a"
-OPTS_PS="auxfww"
-OPTS_PSTREE="-p"
-OPTS_VMSTAT="-S M 1 3"
-OPTS_STATUSURL="http://localhost:80/server-status"
+declare -r default_OPTS_LINKS="-dump"
+declare -r default_OPTS_DF="-x nfs"
+declare -r default_OPTS_FDISK="-l"
+declare -r default_OPTS_FREE=""
+declare -r default_OPTS_IOSTAT="-t -x 1 3"
+declare -r default_OPTS_IOTOP="-b -o -t -n 3"
+declare -r default_OPTS_NETSTAT="-atunp"
+declare -r default_OPTS_NETSTAT_SUM="-a"
+declare -r default_OPTS_PS="auxfww"
+declare -r default_OPTS_PSTREE="-p"
+declare -r default_OPTS_VMSTAT="-S M 1 3"
+declare -r default_OPTS_STATUSURL="http://localhost:80/server-status"
+OPTS_LINKS="${default_OPTS_LINKS}"
+OPTS_DF="${default_OPTS_DF}"
+OPTS_FDISK="${default_OPTS_FDISK}"
+OPTS_FREE="${default_OPTS_FREE}"
+OPTS_IOSTAT="${default_OPTS_IOSTAT}"
+OPTS_IOTOP="${default_OPTS_IOTOP}"
+OPTS_NETSTAT="${default_OPTS_NETSTAT}"
+OPTS_NETSTAT_SUM="${default_OPTS_NETSTAT_SUM}"
+OPTS_PS="${default_OPTS_PS}"
+OPTS_PSTREE="${default_OPTS_PSTREE}"
+OPTS_VMSTAT="${default_OPTS_VMSTAT}"
+OPTS_STATUSURL="${default_OPTS_STATUSURL}"
 
 # Functions
 
@@ -250,14 +285,26 @@ print_http_fullstatus() {
 print_netstat() {
   local LOGFILE="$1"
   echo "Network connections" >> "${LOGFILE}"
-  ss ${OPTS_NETSTAT} >> "${LOGFILE}"
+  if ss ${OPTS_NETSTAT} &>/dev/null; then
+    ss ${OPTS_NETSTAT} >> "${LOGFILE}"
+  else
+    ss ${default_OPTS_NETSTAT} >> "${LOGFILE}"
+    echo -e "\nBad config: '${OPTS_NETSTAT}', "\
+            "using default: '${default_OPTS_NETSTAT}'" >> "${LOGFILE}"
+  fi
 }
 
 # Print the output of "nstat -a" to the specified file
 print_netstat_sum() {
   local LOGFILE="$1"
   echo "Network traffic summary" >> "${LOGFILE}"
-  nstat ${OPTS_NETSTAT_SUM} >> "${LOGFILE}"
+  if nstat ${OPTS_NETSTAT_SUM} &>/dev/null; then
+    nstat ${OPTS_NETSTAT_SUM} >> "${LOGFILE}"
+  else
+    nstat ${default_OPTS_NETSTAT_SUM} >> "${LOGFILE}"
+    echo -e "\nBad config: '${OPTS_NETSTAT_SUM}', "\
+            "using default: '${default_OPTS_NETSTAT_SUM}'" >> "${LOGFILE}"
+  fi
 }
 
 # Print the output of "mysqladmin status" to the mysql file

--- a/src/recap
+++ b/src/recap
@@ -101,7 +101,7 @@ OPTS_FREE=""
 OPTS_IOSTAT="-t -x 1 3"
 OPTS_IOTOP="-b -o -t -n 3"
 OPTS_NETSTAT="-ntulpae"
-OPTS_NETSTAT_SUM="-s"
+OPTS_NETSTAT_SUM="-a"
 OPTS_PS="auxfww"
 OPTS_PSTREE="-p"
 OPTS_VMSTAT="-S M 1 3"
@@ -253,11 +253,11 @@ print_netstat() {
   netstat ${OPTS_NETSTAT} >> "${LOGFILE}"
 }
 
-# Print the output of "netstat -s" to the specified file
+# Print the output of "nstat -a" to the specified file
 print_netstat_sum() {
   local LOGFILE="$1"
   echo "Network traffic summary" >> "${LOGFILE}"
-  netstat ${OPTS_NETSTAT_SUM} >> "${LOGFILE}"
+  nstat ${OPTS_NETSTAT_SUM} >> "${LOGFILE}"
 }
 
 # Print the output of "mysqladmin status" to the mysql file

--- a/src/recap
+++ b/src/recap
@@ -100,7 +100,7 @@ OPTS_FDISK="-l"
 OPTS_FREE=""
 OPTS_IOSTAT="-t -x 1 3"
 OPTS_IOTOP="-b -o -t -n 3"
-OPTS_NETSTAT="-ntulpae"
+OPTS_NETSTAT="-atunp"
 OPTS_NETSTAT_SUM="-a"
 OPTS_PS="auxfww"
 OPTS_PSTREE="-p"
@@ -246,11 +246,11 @@ print_http_fullstatus() {
   links ${OPTS_LINKS} "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
 }
 
-# Print the output of "netstat -ntulpae" to the specified file
+# Print the output of "ss -atunp" to the specified file
 print_netstat() {
   local LOGFILE="$1"
   echo "Network connections" >> "${LOGFILE}"
-  netstat ${OPTS_NETSTAT} >> "${LOGFILE}"
+  ss ${OPTS_NETSTAT} >> "${LOGFILE}"
 }
 
 # Print the output of "nstat -a" to the specified file

--- a/src/recap.5
+++ b/src/recap.5
@@ -102,7 +102,7 @@ Can be set to yes or no depending on whether or not the output of the "pstree" c
 
 .IP \fBUSENETSTAT\fR
 .br
-Can be set to yes or no depending on whether or not the output of "netstat ${OPTS_NETSTAT}" command should be recorded. Please note that this output is written to a separate file in
+Can be set to yes or no depending on whether or not the output of "ss ${OPTS_NETSTAT}" command should be recorded. Please note that this output is written to a separate file in
 .IR ${BASEDIR}/netstat.log
 is required by USENETSTATSUM.
 (default: yes)
@@ -178,8 +178,8 @@ iotop options
 
 .IP \fBOPTS_NETSTAT\fR
 .br
-netstat options
-(default: "\-ntulpae")
+ss options
+(default: "\-atunp")
 
 .IP \fBOPTS_NETSTAT_SUM\fR
 .br

--- a/src/recap.5
+++ b/src/recap.5
@@ -109,7 +109,7 @@ is required by USENETSTATSUM.
 
 .IP \fBUSENETSTATSUM\fR
 .br
-Can be set to yes or no depending on whether or not the output of "netstat ${OPTS_NETSTAT_SUM}" command should be recorded. This report requires that USENETSTAT be set to "yes". This output is written in
+Can be set to yes or no depending on whether or not the output of "nstat ${OPTS_NETSTAT_SUM}" command should be recorded. This report requires that USENETSTAT be set to "yes". This output is written in
 .IR ${BASEDIR}/netstat.log
 (default: no)
 
@@ -183,8 +183,8 @@ netstat options
 
 .IP \fBOPTS_NETSTAT_SUM\fR
 .br
-netstat statistics options
-(default: "\-s")
+nstat statistics options
+(default: "\-a")
 
 .IP \fBOPTS_PS\fR
 .br

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -86,7 +86,7 @@
 # Example, to disable: USENETSTATSUM="no"
 #USENETSTAT="yes"
 
-# USENETSTATSUM - Generates logs from "netstat ${OPTS_NETSTAT_SUM}".
+# USENETSTATSUM - Generates logs from "nstat ${OPTS_NETSTAT_SUM}".
 # requires: USENETSTAT
 # Example, to enable: USENETSTATSUM="yes"
 #USENETSTATSUM="no"
@@ -194,10 +194,10 @@
 # Example: OPTS_NETSTAT="-punteCola"
 #OPTS_NETSTAT="-ntulpae"
 
-# OPTS_NETSTAT_SUM - netstat statistics options
+# OPTS_NETSTAT_SUM - nstat options
 # Required by: USENETSTATSUM
-# Example: OPTS_NETSTAT_SUM="-stuUSw"
-#OPTS_NETSTAT_SUM="-s"
+# Example: OPTS_NETSTAT_SUM="-z"
+#OPTS_NETSTAT_SUM="-a"
 
 # OPTS_PS - ps options
 # Required by: USEPS

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -81,7 +81,7 @@
 #USEINNODB="no"
 
 ## Report: netstat
-# USENETSTAT - Generates network stats from "netstat ${OPTS_NETSTAT}"
+# USENETSTAT - Generates network stats from "ss ${OPTS_NETSTAT}"
 # Required by: USENETSTATSUM
 # Example, to disable: USENETSTATSUM="no"
 #USENETSTAT="yes"
@@ -189,10 +189,10 @@
 # Example: OPTS_IOTOP="-botqn3 -d3"
 #OPTS_IOTOP="-b -o -t -n 3"
 
-# OPTS_NETSTAT - netstat options
+# OPTS_NETSTAT - ss options
 # Required by: USENETSTAT
-# Example: OPTS_NETSTAT="-punteCola"
-#OPTS_NETSTAT="-ntulpae"
+# Example: OPTS_NETSTAT="-atunompie"
+#OPTS_NETSTAT="-atunp"
 
 # OPTS_NETSTAT_SUM - nstat options
 # Required by: USENETSTATSUM

--- a/src/recaptool
+++ b/src/recaptool
@@ -82,7 +82,7 @@ net() {
 	>"${TMP}"
 	for i in $( ls "${BASEDIR}"/netstat_*.log ); do
 		head -n 1 "${i}" | tr "\n" "\t" >> "${TMP}"
-		egrep ":${PORT} " "${i}" -c >> "${TMP}"
+		egrep -c ":${PORT} " "${i}" >> "${TMP}"
 	done
 	sort "${TMP}"
 	rm -f "${TMP}"
@@ -94,7 +94,7 @@ netestab() {
 	>"${TMP}"
 	for i in $( ls "${BASEDIR}"/netstat_*.log ); do
 		head -n 1 "${i}" | tr "\n" "\t" >> "${TMP}"
-		egrep ":${PORT} .*ESTAB" "${i}" -c >> "${TMP}"
+		egrep -c "ESTAB .*:${PORT} " "${i}" >> "${TMP}"
 	done
 	sort "${TMP}"
 	rm -f "${TMP}"


### PR DESCRIPTION
Fix #107 

- Deprecates the use of `netstat` to generate reports
- The replacements are: `nstat` and `ss` both provided through `iproute2` utilities (Red Hat names the package of this utilities `iproute`)
- Log report file does **not** change, remains being: `${BASEDIR}/netstat_<timestamp>.log`
- Options and Command options **names** remain the **same**:
  - `USENETSTAT`, `USENETSTATSUM`.
  - `OPTS_NETSTAT`, `OPTS_NETSTAT_SUM`.
- Default values have changed **only** for command options:
  - `OPTS_NETSTAT` - `-atunp`
  - `OPTS_NETSTAT_SUM` - `-a`
- Content of the reports change due to the nature of the new tools, examples of the old vs new are included in this gist: https://gist.github.com/tonyskapunk/f343648806d5d1db279aad1a7958b666
