### PR TITLE
Deprecate the use of OPT_CURL in favor of OPTS_LINKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+- Deprecated the use of OPTS_CURL in favor of OPTS_LINKS
+- Default changed for OPTS_STATUSURL
+
 ## [1.1.0] - 2017-09-01
 - Align default settings on recap.conf to script defaults.
 - Default setting changed for: USEDF, USENETSTAT, OPTS_PSTREE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Contribution guidelines can be found in [CONTRIBUTING.md](https://github.com/rac
 - gawk
 - grep
 - iotop
+- links
 - net-tools
 - procps
 - psmisc

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ Options used by the tools generating the reports
 
   Default: `MYSQL_PROCESS_LIST="table"`
 
-- **OPTS_CURL** - Options used by curl.
+- **OPTS_LINKS** - Options used by links.
   Required by: `USEFULLSTATUS`
 
-  Default: `OPTS_CURL="-Ls"`
+  Default: `OPTS_LINKS="-dump"`
 
 - **OPTS_DF** - df options
 
@@ -324,7 +324,7 @@ Options used by the tools generating the reports
 
   Required by: `USEFULLSTATUS`
 
-  Default: `OPTS_STATUSURL="http://localhost:80/"`
+  Default: `OPTS_STATUSURL="http://localhost:80/server-status"`
 
 - **OPTS_VMSTAT** - vmstat options
 

--- a/src/recap
+++ b/src/recap
@@ -95,7 +95,7 @@ USEINNODB="no"
 USEMYSQLPROCESSLIST="no"
 
 # Default command options(can be overriden in config file)
-OPTS_CURL="-Ls"
+OPTS_LINKS="-dump"
 OPTS_DF="-x nfs"
 OPTS_FDISK="-l"
 OPTS_FREE=""
@@ -106,7 +106,7 @@ OPTS_NETSTAT_SUM="-s"
 OPTS_PS="auxfww"
 OPTS_PSTREE="-p"
 OPTS_VMSTAT="-S M 1 3"
-OPTS_STATUSURL="http://localhost:80/"
+OPTS_STATUSURL="http://localhost:80/server-status"
 
 # Functions
 
@@ -244,7 +244,7 @@ print_sar() {
 print_http_fullstatus() {
   local LOGFILE="$1"
   echo "Web Status report" >> "${LOGFILE}"
-  curl ${OPTS_CURL} "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
+  links ${OPTS_LINKS} "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
 }
 
 # Print the output of "netstat -ntulpae" to the specified file
@@ -475,7 +475,7 @@ run_resources_report() {
   fi
 
   # check to see if webserver fullstatus should be run
-  type -p 'curl' > /dev/null
+  type -p 'links' > /dev/null
   if [[ $? -eq 0 && "${USEFULLSTATUS,,}" == "yes" ]]; then
     print_blankline "${ITEM_FILE}"
     print_http_fullstatus "${ITEM_FILE}"

--- a/src/recap.5
+++ b/src/recap.5
@@ -151,10 +151,10 @@ Option required by USEMYSQL, USEMYSQLPROCESSLIST, USEINNODB, defines the path to
 Format to display MySQL process list, options are "table" or "vertical". This requires that USEMYSQLPROCESSLIST be set "yes".
 (default: table).
 
-.IP \fBOPTS_CURL\fR
+.IP \fBOPTS_LINKS\fR
 .br
-Options used by curl, when using USEFULLSTATUS
-(default: '\-Ls')
+Options used by links, when using USEFULLSTATUS
+(default: '\-dump')
 
 .IP \fBOPTS_DF\fR
 .br
@@ -204,7 +204,7 @@ pstree options
 .IP \fBOPTS_STATUSURL\fR
 .br
 URL to perform the http request when USEFULLSTATUS is enabled.
-(default: "http://localhost:80/")
+(default: "http://localhost:80/server-status")
 
 .IP \fBOPTS_VMSTAT\fR
 .br

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -157,10 +157,10 @@
 # Example, generate vertical output: MYSQL_PROCESS_LIST="vertical"
 #MYSQL_PROCESS_LIST="table"
 
-# OPTS_CURL - Options used by curl, when using USEFULLSTATUS
+# OPTS_LINKS- Options used by links, when using USEFULLSTATUS
 # Required by: USEFULLSTATUS
-# Example: OPTS_CURL="-skLv"
-#OPTS_CURL="-Ls"
+# Example: OPTS_LINKS="-dump -width 120 -codepage iso-8859-2"
+#OPTS_LINKS="-dump"
 
 # OPTS_DF - df options
 # Required by: USEDF
@@ -213,7 +213,7 @@
 # enabled
 # Required by: USEFULLSTATUS
 # Example: OPTS_STATUSURL="http://localhost/nginx_status"
-#OPTS_STATUSURL="http://localhost:80/"
+#OPTS_STATUSURL="http://localhost:80/server-status"
 
 # OPTS_VMSTAT - vmstat options
 # Required by: USERESOURCES


### PR DESCRIPTION
The introduction of the use of `curl` and its options(`OPTS_CURL`) produced a non easy-to-read log file, changing it to the use of `links` to make it readable and still avoid the dependency of using `apache httpd` packages.

---
Fix #125 