### PR TITLE
Deprecating MAXLOAD, adding timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [Unreleased]
 - Deprecated the use of OPTS_CURL in favor of OPTS_LINKS
 - Default changed for OPTS_STATUSURL
+- Deprecated the use of MAXLOAD. [(#123)][1]
+- Timeout added to cronjobs with a default of 5m for most cases. [(#123)][1]
 
 ## [1.1.0] - 2017-09-01
 - Align default settings on recap.conf to script defaults.
@@ -149,3 +151,6 @@ All notable changes to this project will be documented in this file.
 - Simone Soldateschi (siso)
 - Tony Garcia (tonyskapunk)
 
+---
+
+[1]: https://github.com/rackerlabs/recap/issues/123 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Contribution guidelines can be found in [CONTRIBUTING.md](https://github.com/rac
 
 ## Dependencies
 - bash >= 4
-- bc
 - coreutils
 - gawk
 - grep
@@ -122,10 +121,6 @@ The following variables are commented out with the defaults values in the config
 - **MIN_FREE_SPACE** - Minimum free space (in MB) required in `${BASEDIR}` to run recap, a value of 0 deactivates this check.
 
   Default: `MIN_FREE_SPACE=0`
-
-- **MAXLOAD** - Maximum load allowed to run recap, abort if load is higher than this value.
-
-  Default: `MAXLOAD=10`
 
 
 #### Reports

--- a/src/recap
+++ b/src/recap
@@ -65,7 +65,6 @@ SNAPSHOT="no"
 BACKUP_ITEMS="fdisk mysql netstat ps pstree resources"
 BASEDIR="/var/log/recap"
 MAILTO=""
-MAXLOAD=$(( $( grep -c sibling /proc/cpuinfo ) * 10 ))
 MIN_FREE_SPACE=0
 USEFDISK="no"
 USEPS="yes"
@@ -589,14 +588,6 @@ elif [[ ! -r /etc/recap ]]; then
 	echo "No configuration file found. Proceeding with defaults."
 else
 	source /etc/recap
-fi
-
-# Quit if load is higher than MAXLOAD
-LOAD=$( grep -Po '^[\d\.]+' /proc/loadavg )
-QUIT=$( bc -l <<< "${LOAD}>${MAXLOAD}" )
-if [[ ${QUIT} -eq 1 ]]; then
-  echo "QUIT (LOAD:"${LOAD}", MAXLOAD:"${MAXLOAD}")"
-  exit 1
 fi
 
 # Evaluate input flags, print usage if more than one flag is used.

--- a/src/recap.5
+++ b/src/recap.5
@@ -48,11 +48,6 @@ Directory where recap logs will be written, if defined is used by recaplog and r
 .br
 Define this variable if you would like the reports to be sent via email
 
-IP \fBMAXLOAD\fR
-.br
-The maximum load allowed to run recap, abort if load is higher than this value. Default is calculated dynamically 10 times the number of CPUs identified by the kernel.
-(default: 10*CPUs)
-
 .IP \fBMIN_FREE_SPACE\fR
 .br
 The minimum free disk space (in MB) required in ${BASEDIR} to run recap. (Disabled by default)

--- a/src/recap.cron.in
+++ b/src/recap.cron.in
@@ -2,32 +2,32 @@
 #uncomment for the files you want saved
 
 # runs at boot, backup the last set of reports generated prior to a reboot
-@reboot root @BINDIR@/recap -B
+@reboot root timeout 5m @BINDIR@/recap -B
 
 #The following are examples of times to run recap
 #This file should be in /etc/cron.d
 #Only uncomment or create one active line per installation
 
 #At 2am every day
-#0 2 * * * root @BINDIR@/recap
+#0 2 * * * root timeout 5m @BINDIR@/recap
 
 #At 2am and 2pm every day
-#0 2,14 * * * root @BINDIR@/recap
+#0 2,14 * * * root timeout 5m @BINDIR@/recap
 
 #At 2am, 8am, 2pm, 8pm every day
-#0 2,8,14,20 * * * root @BINDIR@/recap
+#0 2,8,14,20 * * * root timeout 5m @BINDIR@/recap
 
 #Every hour
-#0 * * * * root @BINDIR@/recap
+#0 * * * * root timeout 5m @BINDIR@/recap
 
 #Every 30 minutes
-#*/30 * * * * root @BINDIR@/recap
+#*/30 * * * * root timeout 5m @BINDIR@/recap
 
 #Every 10 minutes
-*/10 * * * * root @BINDIR@/recap
+*/10 * * * * root timeout 5m @BINDIR@/recap
 
 #Every 5 minutes
-#*/5 * * * * root @BINDIR@/recap
+#*/5 * * * * root timeout 4m @BINDIR@/recap
 
 # Pack and clear log files
 0 1 * * * root @BINDIR@/recaplog


### PR DESCRIPTION
- Deprecated the use of `MAXLOAD`.
- Timeout added to cronjobs with a default of 5m for most cases.

---

If any old configuration is making use of `MAXLOAD`, this will be simply ignored.

Fix #123 