### PR TITLE
Pre-decommission of /etc/recap in favor of /etc/recap.conf.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install-base:
 	@install -Dm0755 src/recaplog $(DESTDIR)$(BINDIR)/recaplog
 	@install -Dm0755 src/recaptool $(DESTDIR)$(BINDIR)/recaptool
 	@echo "Installing configuration..."
-	@install -Dm0644 src/recap.conf $(DESTDIR)$(SYSCONFDIR)/recap
+	@install -Dm0644 src/recap.conf $(DESTDIR)$(SYSCONFDIR)/recap.conf
 	@echo "Creating log directories..."
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap
 	@install -dm0755 $(DESTDIR)$(LOGDIR)/recap/backups

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The cron file (`/etc/cron.d/recap`) is used to determine the execution time of `
 
 ### Configuration
 
-The following variables are commented out with the defaults values in the configuration file `/etc/recap` which can be overriden.
+The following variables are commented out with the defaults values in the configuration file `/etc/recap.conf` which can be overriden.
 
 #### Settings shared by recap scripts
 

--- a/src/recap
+++ b/src/recap
@@ -17,17 +17,6 @@
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #
-# The cron execution file is in /etc/cron.d
-#
-# The variable configuration file for recap is in /etc/recap
-#
-# All the variables defined here and several others can be defined in the variable
-# configuration file.  You can see more on these in /usr/share/doc/recap-{version}/README
-#
-# Define the default environment for recap
-# DO NOT change these values here, user-modifiable options can be tweaked through
-# /etc/recap
-#
 #~ Usage: _tool_ [OPTION]
 #~ Options:
 #~   -h,--help       Print this help.
@@ -697,6 +686,29 @@ check_disk_space() {
 }
 
 ## Main
+
+# Check for the configuration file.
+# The following create awareness about the new the config location in
+# /etc/recap.conf, taking precendence the actual /etc/recap config.
+if [[ -r /etc/recap &&
+      -r /etc/recap.conf ]]; then
+  log WARNING "Configuration files exist at old(/etc/recap) and"\
+              "new(/etc/recap.conf) locations. The file from the old"\
+              "location will be read."
+  log WARNING "Please move your configuration to /etc/recap.conf."
+  source /etc/recap
+elif [[ -r /etc/recap &&
+        ! -r /etc/recap.conf ]]; then
+  log WARNING "Configuration file exists at old(/etc/recap) location. "\
+              "The file will be read."
+              "Please move your configuration file to /etc/recap.conf."
+  source /etc/recap
+elif [[ ! -r /etc/recap.conf ]]; then
+  log WARNING "No configuration file found. Expecting /etc/recap.conf."
+  log WARNING "Proceeding with defaults."
+else
+  source /etc/recap.conf
+fi
 
 # Evaluate input flags, print usage if more than one flag is used.
 if [[ "$#" -gt 1 ]]; then

--- a/src/recap.5
+++ b/src/recap.5
@@ -28,7 +28,7 @@ recap - dumps periodic information about running applications and resource usage
 recap is a user-configurable script that can be run once, or run periodically out of cron to dump information about running processes and resource usage. It is useful on servers that have periodic, mysterious performance anomalies for tracking down what may be going on at the time of any particular incident.
 
 The default values for which reports are generated and how many reports are stored can be
-.IR /etc/recap "."
+.IR /etc/recap.conf "."
 The output files from the script are written to
 .IR BASEDIR "."
 .SH OPTIONS

--- a/src/recap.8
+++ b/src/recap.8
@@ -28,7 +28,7 @@ recap - dumps periodic information about running applications and resource usage
 recap is a user-configurable script that can be run once, or run periodically out of cron or systemd.timers to dump information about running processes and resource usage. It's useful on servers that have periodic, mysterious performance anomalies for tracking down what may be going on at the time of any particular incident.
 
 The values for which reports are generated and how many reports are stored can be overridden in
-.IR /etc/recap "."
+.IR /etc/recap.conf "."
 The output files from the script are written to
 .IR BASEDIR "."
 .TP
@@ -43,6 +43,7 @@ Print version and exit.
 .TP
 .SH FILES
 .nf
+/etc/recap.conf
 /etc/cron.d/recap
 /etc/recap
 /usr/lib/systemd/sytem/recap.{service,timer} - Unit files for running recap periodically.

--- a/src/recaplog
+++ b/src/recaplog
@@ -17,17 +17,6 @@
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #
-# The cron execution file is in /etc/cron.d
-#
-# The variable configuration file for 'recaplog' is in /etc/recap
-#
-# All the variables defined here and several others can be defined in the variable
-# configuration file.  You can see more on these in /usr/share/doc/recap-{version}/README
-#
-# Define the default environment for recap
-# DO NOT change these values here, user-modifiable options can be tweaked through
-# /etc/recap
-#
 #~ Usage: _tool_ [-hnv]
 #~ Options:
 #~   -h             Print this help.
@@ -266,21 +255,27 @@ if [[ "$( id -u )" != "0" ]]; then
   exit 1
 fi
 
-# Parse configuration file
-# check to see where the configuration file is located.
-# if the file is not at /etc/recap, make some noise to alert users
-if [[ -f /etc/sysconfig/recap &&
-      -f /etc/recap ]]; then
-  log WARNING "Configuration files exist at old (/etc/sysconfig/recap) and new locations (/etc/recap). The file from the old location will be read. Please consolidate your configuration details into /etc/recap."
-  source /etc/sysconfig/recap
-elif [[ -f /etc/sysconfig/recap &&
-        ! -f /etc/recap ]]; then
-  log WARNING "Configuration file exists at old location (/etc/sysconfig/recap). The file will be read. Please move your configuration file to /etc/recap."
-  source /etc/sysconfig/recap
-elif [[ ! -f /etc/recap ]]; then
-  log WARNING "No configuration file found. Proceeding with defaults."
-else
+# Check for the configuration file.
+# The following create awareness about the new the config location in
+# /etc/recap.conf, taking precendence the actual /etc/recap config.
+if [[ -r /etc/recap &&
+      -r /etc/recap.conf ]]; then
+  log WARNING "Configuration files exist at old(/etc/recap) and"\
+              "new(/etc/recap.conf) locations. The file from the old"\
+              "location will be read."
+  log WARNING "Please move your configuration to /etc/recap.conf."
   source /etc/recap
+elif [[ -r /etc/recap &&
+        ! -r /etc/recap.conf ]]; then
+  log WARNING "Configuration file exists at old(/etc/recap) location."\
+              "The file will be read."
+  log WARNING "Please move your configuration file to /etc/recap.conf."
+  source /etc/recap
+elif [[ ! -r /etc/recap.conf ]]; then
+  log WARNING "No configuration file found. Expecting /etc/recap.conf."
+  log WARNING "Proceeding with defaults."
+else
+  source /etc/recap.conf
 fi
 
 # Define the headers for the run

--- a/src/recaptool
+++ b/src/recaptool
@@ -33,7 +33,7 @@ declare -r _VERSION='1.2.0'
 ## Default settings
 BASEDIR="/var/log/recap"
 cmds=""
-CONFFILE="/etc/recap"
+CONFFILE="/etc/recap.conf"
 
 ## Overriding defaults
 if [[ -r "${CONFFILE}" ]]; then


### PR DESCRIPTION
These changes should slowly(through one release) warn about the lack of the new location of the config:
-  `/etc/recap.conf`

In case that's missing the old location is read `/etc/recap`, the old location has precedence over the new location for at least one release.

Fix #80 