### PR TITLE
Fix log format and cleanup function on recaplog.

### DIFF
--- a/src/recaplog
+++ b/src/recaplog
@@ -218,6 +218,7 @@ pack_old_logs() {
 cleanup() {
   log INFO "$( basename $0 ) ($$): Caught signal - deleting ${LOCKFILE}"
   rm -f "${LOCKFILE}"
+  log INFO "${banner_end}"
 }
 
 # Create a Lock so that recaplog does not try to run over itself.
@@ -227,7 +228,7 @@ recaploglock() {
     log ERROR "$( basename $0 ) ($$): Lock File exists - exiting"
     exit 1
   else
-    trap 'cleanup; exit 2' 1 2 15 17 19 23
+    trap 'exit 2' 1 2 15 17 19 23
     trap 'cleanup' EXIT
     log INFO "$( basename $0 ) ($$): Created lock file: ${LOCKFILE}"
   fi
@@ -282,21 +283,23 @@ else
   source /etc/recap
 fi
 
-# Aquire lock
-recaploglock
 # Define the headers for the run
 if [[ "${DRYRUN}" ]]; then
-  banner_start="--- Starting dry run ---"
-  banner_end="--- Ending dry run ---"
+  banner_start="--- Starting $( basename $0 )[$$] (dry-run) ---"
+  banner_end="--- Ending $( basename $0 )[$$] (dry-run) ---"
 else
-  banner_start="--- Starting run ---"
-  banner_end="--- Ending run ---"
+  banner_start="--- Starting $( basename $0 )[$$] ---"
+  banner_end="--- Ending $( basename $0 )[$$] ---"
 fi
 
-# recap the logs
+# Start logging
 log INFO "${banner_start}"
+
+# Aquire lock
+recaploglock
+
+# recap the logs
 pack_old_logs
 delete_old_logs
-log INFO "${banner_end}"
 
 exit 0


### PR DESCRIPTION
Fix #140 

Before:
  ```log
2017-11-22 01:00:01-06:00 [INFO] recaplog (29594): Created lock file: /var/lock/
recaplog.lock
2017-11-22 01:00:01-06:00 [INFO] --- Starting run ---
2017-11-22 01:00:01-06:00 [INFO] Compressing old log files
2017-11-22 01:00:01-06:00 [INFO] Packing fdisk...
2017-11-22 01:00:01-06:00 [ERROR] recaplog (29611): Lock File exists - exiting
2017-11-22 01:00:01-06:00 [ERROR] An error ocurred while reading logs: 'ls: cann
ot access '/var/log/recap/fdisk_20171121-*.log': No such file or directory', ski
pping...
2017-11-22 01:00:01-06:00 [INFO] Packing mysql...
2017-11-22 01:00:01-06:00 [ERROR] An error ocurred while reading logs: 'ls: cann
ot access '/var/log/recap/mysql_20171121-*.log': No such file or directory', ski
pping...
2017-11-22 01:00:01-06:00 [INFO] Packing netstat...
2017-11-22 01:00:01-06:00 [INFO] Moving 69 logs to: /var/log/recap/netstat_daily
_20171121
2017-11-22 01:00:01-06:00 [INFO] Compressing 69 logs into: /var/log/recap/netsta
t_daily_20171121.log.tar.gz
2017-11-22 01:00:01-06:00 [INFO] Deleting 69 logs.
2017-11-22 01:00:01-06:00 [INFO] Packing ps...
2017-11-22 01:00:01-06:00 [INFO] Moving 69 logs to: /var/log/recap/ps_daily_2017
1121
2017-11-22 01:00:01-06:00 [INFO] Compressing 69 logs into: /var/log/recap/ps_dai
ly_20171121.log.tar.gz
2017-11-22 01:00:01-06:00 [INFO] Deleting 69 logs.
2017-11-22 01:00:01-06:00 [INFO] Packing pstree...
2017-11-22 01:00:01-06:00 [INFO] Moving 68 logs to: /var/log/recap/pstree_daily_
20171121
2017-11-22 01:00:01-06:00 [INFO] Compressing 68 logs into: /var/log/recap/pstree
_daily_20171121.log.tar.gz
2017-11-22 01:00:01-06:00 [INFO] Deleting 68 logs.
2017-11-22 01:00:01-06:00 [INFO] Packing resources...
2017-11-22 01:00:01-06:00 [INFO] Moving 69 logs to: /var/log/recap/resources_dai
ly_20171121
2017-11-22 01:00:01-06:00 [INFO] Compressing 69 logs into: /var/log/recap/resour
ces_daily_20171121.log.tar.gz
2017-11-22 01:00:01-06:00 [INFO] Deleting 69 logs.
2017-11-22 01:00:01-06:00 [INFO] Deleting log files older than 15 days...
2017-11-22 01:00:01-06:00 [INFO] Deleting: 0 log files.
2017-11-22 01:00:01-06:00 [INFO] Deleting: 0 empty directories.
2017-11-22 01:00:01-06:00 [INFO] --- Ending run ---
2017-11-22 01:00:01-06:00 [INFO] recaplog (29594): Caught signal - deleting /var
/lock/recaplog.lock
```

Now looks like this:

Dry-run:
  ```log
2017-11-29 15:52:59-06:00 [INFO] --- Starting recaplog[29974] (dry-run) ---
2017-11-29 15:52:59-06:00 [INFO] recaplog (29974): Created lock file: /var/lock/recaplog.lock
2017-11-29 15:52:59-06:00 [INFO] Compressing old log files
2017-11-29 15:52:59-06:00 [INFO] Packing fdisk...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/fdisk_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Packing mysql...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/mysql_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Packing netstat...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/netstat_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Packing ps...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/ps_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Packing pstree...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/pstree_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Packing resources...
2017-11-29 15:52:59-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/resources_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:52:59-06:00 [INFO] Deleting log files older than 15 days...
2017-11-29 15:52:59-06:00 [INFO] Would delete: 0 log files.
2017-11-29 15:52:59-06:00 [INFO] recaplog (29974): Caught signal - deleting /var/lock/recaplog.lock
2017-11-29 15:52:59-06:00 [INFO] --- Ending recaplog[29974] (dry-run) ---
```

Regular Run:
  ```log
2017-11-29 15:55:53-06:00 [INFO] --- Starting recaplog[30607] ---
2017-11-29 15:55:53-06:00 [INFO] recaplog (30607): Created lock file: /var/lock/recaplog.lock
2017-11-29 15:55:53-06:00 [INFO] Compressing old log files
2017-11-29 15:55:53-06:00 [INFO] Packing fdisk...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/fdisk_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Packing mysql...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/mysql_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Packing netstat...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/netstat_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Packing ps...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/ps_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Packing pstree...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/pstree_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Packing resources...
2017-11-29 15:55:53-06:00 [ERROR] An error ocurred while reading logs: 'ls: cannot access '/var/log/recap/resources_20171128-*.log': No such file or directory', skipping...
2017-11-29 15:55:53-06:00 [INFO] Deleting log files older than 5 days...
2017-11-29 15:55:53-06:00 [INFO] Deleting: 16 log files.
2017-11-29 15:55:53-06:00 [INFO] Deleting: 0 empty directories.
2017-11-29 15:55:53-06:00 [INFO] recaplog (30607): Caught signal - deleting /var/lock/recaplog.lock
2017-11-29 15:55:53-06:00 [INFO] --- Ending recaplog[30607] ---

```