### PR TITLE
Remove dup of config read and fix order on recap/recaplog.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -687,29 +687,6 @@ check_disk_space() {
 
 ## Main
 
-# Check for the configuration file.
-# The following create awareness about the new the config location in
-# /etc/recap.conf, taking precendence the actual /etc/recap config.
-if [[ -r /etc/recap &&
-      -r /etc/recap.conf ]]; then
-  log WARNING "Configuration files exist at old(/etc/recap) and"\
-              "new(/etc/recap.conf) locations. The file from the old"\
-              "location will be read."
-  log WARNING "Please move your configuration to /etc/recap.conf."
-  source /etc/recap
-elif [[ -r /etc/recap &&
-        ! -r /etc/recap.conf ]]; then
-  log WARNING "Configuration file exists at old(/etc/recap) location. "\
-              "The file will be read."
-              "Please move your configuration file to /etc/recap.conf."
-  source /etc/recap
-elif [[ ! -r /etc/recap.conf ]]; then
-  log WARNING "No configuration file found. Expecting /etc/recap.conf."
-  log WARNING "Proceeding with defaults."
-else
-  source /etc/recap.conf
-fi
-
 # Evaluate input flags, print usage if more than one flag is used.
 if [[ "$#" -gt 1 ]]; then
  log ERROR "Error: Only one flag is allowed"
@@ -758,20 +735,27 @@ HOSTNAME="$( hostname )"
 log INFO "${banner_start}"
 log INFO "-- bash info: ${BASH_VERSINFO[@]}"
 
-# Check to see where the configuration file is located.
-# If the file is not at /etc/recap, make some noise to alert users
-if [[ -r /etc/sysconfig/recap &&
-      -r /etc/recap ]]; then
-	log WARNING "Configuration files exist at old (/etc/sysconfig/recap) and new locations (/etc/recap). The file from the old location will be read. Please consolidate your configuration details into /etc/recap."
-	source /etc/sysconfig/recap
-elif [[ -r /etc/sysconfig/recap &&
-        ! -r /etc/recap ]]; then
-	log WARNING "Configuration file exists at old location (/etc/sysconfig/recap). The file will be read. Please move your configuration file to /etc/recap."
-	source /etc/sysconfig/recap
-elif [[ ! -r /etc/recap ]]; then
-	log WARNING "No configuration file found. Proceeding with defaults."
+# Check for the configuration file.
+# The following create awareness about the new the config location in
+# /etc/recap.conf, taking precendence the actual /etc/recap config.
+if [[ -r /etc/recap &&
+      -r /etc/recap.conf ]]; then
+  log WARNING "Configuration files exist at old(/etc/recap) and"\
+              "new(/etc/recap.conf) locations. The file from the old"\
+              "location will be read."
+  log WARNING "Please move your configuration to /etc/recap.conf."
+  source /etc/recap
+elif [[ -r /etc/recap &&
+        ! -r /etc/recap.conf ]]; then
+  log WARNING "Configuration file exists at old(/etc/recap) location. "\
+              "The file will be read."
+              "Please move your configuration file to /etc/recap.conf."
+  source /etc/recap
+elif [[ ! -r /etc/recap.conf ]]; then
+  log WARNING "No configuration file found. Expecting /etc/recap.conf."
+  log WARNING "Proceeding with defaults."
 else
-	source /etc/recap
+  source /etc/recap.conf
 fi
 
 # Create lock

--- a/src/recaplog
+++ b/src/recaplog
@@ -255,6 +255,18 @@ if [[ "$( id -u )" != "0" ]]; then
   exit 1
 fi
 
+# Define the headers for the run
+if [[ "${DRYRUN}" ]]; then
+  banner_start="--- Starting $( basename $0 )[$$] (dry-run) ---"
+  banner_end="--- Ending $( basename $0 )[$$] (dry-run) ---"
+else
+  banner_start="--- Starting $( basename $0 )[$$] ---"
+  banner_end="--- Ending $( basename $0 )[$$] ---"
+fi
+
+# Start logging
+log INFO "${banner_start}"
+
 # Check for the configuration file.
 # The following create awareness about the new the config location in
 # /etc/recap.conf, taking precendence the actual /etc/recap config.
@@ -277,18 +289,6 @@ elif [[ ! -r /etc/recap.conf ]]; then
 else
   source /etc/recap.conf
 fi
-
-# Define the headers for the run
-if [[ "${DRYRUN}" ]]; then
-  banner_start="--- Starting $( basename $0 )[$$] (dry-run) ---"
-  banner_end="--- Ending $( basename $0 )[$$] (dry-run) ---"
-else
-  banner_start="--- Starting $( basename $0 )[$$] ---"
-  banner_end="--- Ending $( basename $0 )[$$] ---"
-fi
-
-# Start logging
-log INFO "${banner_start}"
 
 # Aquire lock
 recaploglock


### PR DESCRIPTION
Found that when rebasing e8518e4 on #137 I mistakenly duplicated the read log instead of replacing the one already in place, this commit takes care of removing that dup and also re-arranging the order to log in the right order.