### PR TITLE
Makefile tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ recap.cron:
 	@sed -e 's|@BINDIR@|$(BINDIR)|' src/utils/recap.cron.in > src/utils/recap.cron
 
 recap.systemd:
-	@for service_file in $$( ls src/utils/*.service.in ); do \
+	@for service_file in src/utils/*.service.in; do \
     sed -e 's|@BINDIR@|$(BINDIR)|' $${service_file} \
       > $$( echo $${service_file} | sed "s,.in,,"); \
 	done

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ recap.cron:
 
 recap.systemd:
 	@for service_file in src/utils/*.service.in; do \
-    sed -e 's|@BINDIR@|$(BINDIR)|' $${service_file} \
-      > $$( echo $${service_file} | sed "s,.in,,"); \
+	sed -e 's|@BINDIR@|$(BINDIR)|' $${service_file} > $${service_file%.in}; \
 	done
 
 clean:


### PR DESCRIPTION
While looking over #143 I noticed a few inefficiencies.

* `ls` child process for a file listing
* `echo` and `sed` child processes to trim a few characters from a variable name