### PR TITLE
Remove SIGSTOP(19), Fix #149.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -179,7 +179,7 @@ recaplock() {
     log ERROR "$( basename $0 )[$$]: Lock File exists - exiting"
     exit 1
   else
-    trap 'exit 2' 1 2 15 17 19 23
+    trap 'exit 2' 1 2 15 17 23
     trap 'cleanup' EXIT
     log INFO "$( basename $0 )[$$]: Created lock file: ${LOCKFILE}"
   fi

--- a/src/recaplog
+++ b/src/recaplog
@@ -217,7 +217,7 @@ recaploglock() {
     log ERROR "$( basename $0 ) ($$): Lock File exists - exiting"
     exit 1
   else
-    trap 'exit 2' 1 2 15 17 19 23
+    trap 'exit 2' 1 2 15 17 23
     trap 'cleanup' EXIT
     log INFO "$( basename $0 ) ($$): Created lock file: ${LOCKFILE}"
   fi


### PR DESCRIPTION
```bash
$ man trap | grep SIGSTOP
       extension. Setting a trap for SIGKILL or SIGSTOP produces undefined results.
       Trapping  SIGKILL  or  SIGSTOP is syntactically accepted by some historical implementations, but it has no effect. Portable POSIX

```