### PR TITLE
New config file now takes precedence over old one.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -736,20 +736,21 @@ log INFO "${banner_start}"
 log INFO "-- bash info: ${BASH_VERSINFO[@]}"
 
 # Check for the configuration file.
-# The following create awareness about the new the config location in
-# /etc/recap.conf, taking precendence the actual /etc/recap config.
+# The following creates awareness about the old config location in
+# /etc/recap, taking precendence the new config location /etc/recap.conf.
 if [[ -r /etc/recap &&
       -r /etc/recap.conf ]]; then
   log WARNING "Configuration files exist at old(/etc/recap) and"\
-              "new(/etc/recap.conf) locations. The file from the old"\
-              "location will be read."
-  log WARNING "Please move your configuration to /etc/recap.conf."
-  source /etc/recap
+              "new(/etc/recap.conf) locations. The file from the new"\
+              "location will be used."
+  log WARNING "Please move any missing configuration to /etc/recap.conf."
+  source /etc/recap.conf
 elif [[ -r /etc/recap &&
         ! -r /etc/recap.conf ]]; then
-  log WARNING "Configuration file exists at old(/etc/recap) location. "\
-              "The file will be read."
-              "Please move your configuration file to /etc/recap.conf."
+  log WARNING "Configuration file exists at old(/etc/recap) location."\
+              "The file will be read."\
+              "Please move your configuration file to /etc/recap.conf."\
+              "Next version of recap will not read /etc/recap"
   source /etc/recap
 elif [[ ! -r /etc/recap.conf ]]; then
   log WARNING "No configuration file found. Expecting /etc/recap.conf."

--- a/src/recaplog
+++ b/src/recaplog
@@ -268,20 +268,21 @@ fi
 log INFO "${banner_start}"
 
 # Check for the configuration file.
-# The following create awareness about the new the config location in
-# /etc/recap.conf, taking precendence the actual /etc/recap config.
+# The following creates awareness about the old config location in
+# /etc/recap, taking precendence the new config location /etc/recap.conf.
 if [[ -r /etc/recap &&
       -r /etc/recap.conf ]]; then
   log WARNING "Configuration files exist at old(/etc/recap) and"\
-              "new(/etc/recap.conf) locations. The file from the old"\
-              "location will be read."
-  log WARNING "Please move your configuration to /etc/recap.conf."
-  source /etc/recap
+              "new(/etc/recap.conf) locations. The file from the new"\
+              "location will be used."
+  log WARNING "Please move any missing configuration to /etc/recap.conf."
+  source /etc/recap.conf
 elif [[ -r /etc/recap &&
         ! -r /etc/recap.conf ]]; then
   log WARNING "Configuration file exists at old(/etc/recap) location."\
-              "The file will be read."
-  log WARNING "Please move your configuration file to /etc/recap.conf."
+              "The file will be read."\
+              "Please move your configuration file to /etc/recap.conf."\
+              "Next version of recap will not read /etc/recap"
   source /etc/recap
 elif [[ ! -r /etc/recap.conf ]]; then
   log WARNING "No configuration file found. Expecting /etc/recap.conf."


### PR DESCRIPTION
This is continuation of #80 

On the last release [1.3.0](https://github.com/rackerlabs/recap/releases/tag/1.3.0):
  - We started logging warnings about the deprecation of /etc/recap(https://github.com/rackerlabs/recap/pull/137#issuecomment-343617197), `/etc/recap` had precedence if found, then `/etc/recap.conf`.
  - Package wise if a old config was found it was moved to `/etc/recap.conf` (https://github.com/rackerlabs/recap/pull/137#issuecomment-349130798)


Following the plan(https://github.com/rackerlabs/recap/pull/137#issuecomment-344661204) This PR is focusing on the goals for **1.4.0**, the logic is:

  - If both configs(`/etc/recap` and `/etc/recap.conf`) are found, `/etc/recap.conf` takes now precedence.
  - If only `/etc/recap` is found then is read and a warning is logged to let the user know next version this will be ignored.
  - If no config is found a warning is logged, defaults are used.
  - If only `/etc/recap.conf` is found then is read.

---
### version 1.3.0
- Both configs found, old takes precedence:
```log
2018-04-13 11:30:15-05:00 [WARNING] Configuration files exist at old(/etc/recap) and new(/etc/recap.conf) locations. The file from the old location will be read.
2018-04-13 11:30:15-05:00 [WARNING] Please move your configuration to /etc/recap.conf
```

- Only old config is found:
```log
2018-04-13 11:35:36-05:00 [WARNING] Configuration file exists at old(/etc/recap) location.  The file will be read.
/usr/bin/recap: line 752: Please move your configuration file to /etc/recap.conf.: No such file or directory
```

- No config is found:
```log
2018-04-13 11:37:08-05:00 [WARNING] No configuration file found. Expecting /etc/recap.conf.
2018-04-13 11:37:08-05:00 [WARNING] Proceeding with defaults.
```

- No warning is logged when only new config is found

### This PR (intended for 1.4.0) will show:

- Both configs found, new one takes precedence:
```log
2018-04-13 11:46:10-05:00 [WARNING] Configuration files exist at old(/etc/recap) and new(/etc/recap.conf) locations. The file from the new location will be used.
2018-04-13 11:46:10-05:00 [WARNING] Please move any missing configuration to /etc/recap.conf.
```

- Only old config is found:
```log
2018-04-13 11:47:04-05:00 [WARNING] Configuration file exists at old(/etc/recap) location. The file will be read. Please move your configuration file to /etc/recap.conf. Next version of recap will not read /etc/recap
```

- No config is found:
```log
2018-04-13 11:47:43-05:00 [WARNING] No configuration file found. Expecting /etc/recap.conf.
2018-04-13 11:47:43-05:00 [WARNING] Proceeding with defaults.
```

- No warning is logged when only new config is found