### PR TITLE
Add back compatibility to disk space in el6

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -676,7 +676,7 @@ check_disk_space() {
     log INFO "Ended check for disk space"
     return 0
   else
-    FREE_SPACE=$( df -BM --output=avail "${BASEDIR}" | tail -1 )
+    FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' )
     FREE_SPACE=${FREE_SPACE%M}
     if [[ "${MIN_FREE_SPACE}" -ge "${FREE_SPACE}" ]]; then
       log ERROR "Unable to run recap due to not enough disk space"
@@ -761,11 +761,11 @@ fi
 # Create lock
 recaplock
 
-# Check disk space before generating reports
-check_disk_space
-
 # Create output directory if it is not already present
 create_output_dirs
+
+# Check disk space before generating reports
+check_disk_space
 
 # Take a backup when needed
 if [[ "${BACKUP,,}" == "yes" ]]; then


### PR DESCRIPTION
- Adding back the  support to older distros on the check disk space.
- Order of disk space with output_dirs creation to ensure the latter exist prior checking disk space.

Tested on some distros to ensure compatibility:

- debian:7
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102116
  ```
- debian:8
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102078
  ```
- debian:9
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102103
  ```

- centos:6
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102009
  ```
- centos:7
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102004
  ```

- ubuntu:trusty (14.04)
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102010
  ```

- ubuntu:xenial (16.04)
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102119
  ```

- ubuntu:bionic (18.04)
  ```bash
  BASEDIR=/var/log; FREE_SPACE=$( df -PBM "${BASEDIR}" | awk '!/-blocks/ {print $4}' ); FREE_SPACE=${FREE_SPACE%M}; echo ${FREE_SPACE}
  102141
  ```