### PR TITLE
Setting right permissions to BASEDIR on runtime.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -198,6 +198,7 @@ create_output_dirs() {
       mkdir -p "${OUTPUT_DIR}"
     fi
   done
+  chmod 0750 "${BASEDIR}"
 }
 
 # Create output file


### PR DESCRIPTION
Fix #156 