### PR TITLE
Fix bash cond expression.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -401,7 +401,8 @@ print_mysql_innodb_status() {
   local TMPDIR="${MYVALS[3]%/}"
 
   # Next, we grab a list of descriptors in the tmpdir:
-  if [[ -r "${PID_FILE}" -a -d "${TMPDIR}" ]]; then
+  if [[ -r "${PID_FILE}" &&
+        -d "${TMPDIR}" ]]; then
     for name in "/proc/"$(cat ${PID_FILE})"/fd/"*; do
       # We know that InnoDB's temporary files are always in the mysql tmpdir
       # and start with the string 'ib' followed by a randomly generated series


### PR DESCRIPTION
When the expression changed from `[`(test) to bash conditional `[[` the flag was needed to change to evaluate multiple expressions.