### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] -
+- Plugin support
+
+## [1.4.0] - 2018-07-12
+- Continue with the deprecation of `/etc/recap` config file for `/etc/recap.conf`
+  - New config file now takes precedence over old one.
+- Added support to multiple mysql config files.
+- Bug fixes:
+  - Use defaults-file instead of defaults-extra-file
+  - Better handling on stderr.
+  - Disk space compatibility for el6.
+  - Set right perms to BASEDIR on runtime.
+
 ## [1.3.0] - 2017-12-06
 - Start the deprecation of `/etc/recap` config file for `/etc/recap.conf`.
 - Add systemd support for units and timers.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ git checkout ${LATEST} -- debian
 # Build the package
 debuild -us -uc --lintian-opts --profile debian
 
-# Package will be created in ../recap_<version-release>_all.deb
+# Package will be created in ../recap_${latest_tag}-<RELEASE>_all.deb
+# RELEASE comes from the changelog in the debian repository.
 ```
 
 #### Manual install

--- a/README.md
+++ b/README.md
@@ -51,13 +51,60 @@ dnf install recap
 yum install recap
 ```
 
-### Ubuntu
+### Debian / Ubuntu
 
-At the moment there is no public repository for Ubuntu, use the [manual installation](#manual) method.
+At the moment there is no public repository for Debian nor Ubuntu, two options are available:
 
-### Debian
+#### Build a package
 
-At the moment there is no public repository for Debian, use the [manual installation](#manual) method.
+This repository https://github.com/raxpkg/recap contains the debian files required to build a deb package
+
+These are the steps:
+
+```bash
+# Install all the packages required for building the package
+apt-get update
+apt-get install debhelper devscripts git -y
+
+## For Ubuntu:
+apt-get install equivs -y
+
+# Create the working dir:
+mkdir recap
+cd recap
+
+# Get the debian configs
+git init
+git remote add origin https://github.com/raxpkg/recap.git
+git fetch --no-tags origin
+git checkout -qf FETCH_HEAD
+git submodule update --init --recursive
+export LATEST=$( git log --format="%h" --no-merges -1 )
+
+# Build dependencies
+echo "yes" | mk-build-deps --install --remove debian/control
+
+# Get upstream recap code
+git checkout --orphan upstream
+git reset --hard
+git remote add upstream https://github.com/rackerlabs/recap.git
+git fetch -t upstream
+latest_tag=$( git tag | tail -1 )
+git archive ${latest_tag} -o ../recap_${latest_tag}.orig.tar.gz
+tar -zxf ../recap_${latest_tag}.orig.tar.gz
+git fetch --no-tags origin
+git checkout ${LATEST} -- debian
+
+# Build the package
+debuild -us -uc --lintian-opts --profile debian
+
+# Package will be created in ../recap_<version-release>_all.deb
+```
+
+#### Manual install
+
+Use the [manual installation](#manual) method.
+
 
 ### Manual
 

--- a/src/recap
+++ b/src/recap
@@ -26,7 +26,7 @@
 #~
 
 ## Version
-declare -r _VERSION='1.3.0'
+declare -r _VERSION='1.4.0'
 
 ## Default settings(can *NOT* be overriden in config file)
 declare -r DATE=$( date +%F_%T )


### PR DESCRIPTION
- Bump version to 1.4.0
- Include instructions to build deb using https://github.com/raxpkg/recap.git