### PR TITLE
Add ansible playbook to (un)install recap

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,60 @@ The `Makefile` scripts attempts to detect systemd if so, the `install` option wi
 
 Is up to each package distribution to follow their own best practices regarding enabling/disabling the timers on install/remove of the package.
 
+### Ansible
+
+An ansible playbook could be used to install `recap` from a git repository. The playbook is located in `tools` under `ansible_recap.yml` the playbook can be used to install it on Red Hat based and Debian based distros. Or to uninstall it defining the `uninstall` variable.
+
+#### Variables
+
+- `repo` - The location of the repository, default: `https://github.com/rackerlabs/recap.git`.
+- `ref` - The reference to use this could be a branch, a tag or commit, default: `master`.
+- `binpath` - The value of *BINPATH*, default: `/sbin`.
+- `destdir` - The value of *DESTDIR*, default: `""`.
+- `prefix` - The value of *PREFIX*, default: `/usr`.
+- `tmp_install_dir` - The location where the cloned repo will be placed, default: `/tmp/recap`.
+- `uninstall` - Then this is defined it will remove `recap`, default: *undefined*.
+
+#### Install (default)
+
+Install the stable version of `recap`:
+
+```
+ansible-playbook tools/ansible_recap.yml
+```
+
+Install the development version of `recap`:
+
+```
+ansible-playbook tools/ansible_recap.yml -e ref=development
+```
+
+Install branch `foo` from a different repository:
+
+```
+ansible-playbook tools/ansible_recap.yml -e ref=foo -e repo=https://github.com/bar/recap.git
+```
+
+Install recap with *BINPATH* in `/bin`:
+
+```
+ansible-playbook tools/ansible_recap.yml -e binpath=/bin
+```
+
+#### Uninstall
+
+Uninstall `recap` from the default path:
+
+```
+ansible-playbook tools/ansible_recap.yml -e uninstall=yes
+```
+
+Uninstall `recap` from a custom location:
+
+```
+ansible-playbook tools/ansible_recap.yml -e uninstall=yes -e destdir=/tmp/test
+```
+
 ## Cron/Timers and Configuration
 
 ### Timers(systemd)

--- a/tools/ansible_recap.yml
+++ b/tools/ansible_recap.yml
@@ -1,0 +1,93 @@
+---
+- name: Install recap from repo
+  hosts: all
+  become: "yes"
+  vars:
+    repo: https://github.com/rackerlabs/recap.git
+    ref: master
+    binpath: "/sbin"
+    destdir: ""
+    prefix: "/usr"
+    tmp_install_dir: /tmp/recap
+    install_deps:
+      - git
+      - make
+  tasks:
+  - name: Set dependencies
+    set_fact:
+      dependencies:
+        - bash
+        - coreutils
+        - gawk
+        - grep
+        - iotop
+        - "iproute{{'2' if ansible_os_family is match('Debian|Archlinux') else ''}}"
+        - links
+        - "{{ 'procps-ng' if ansible_os_family is match('Archlinux') else 'procps' }}"
+        - psmisc
+        - sysstat
+        - "{{ install_deps }}"
+
+  - name: Install deps
+    package:
+      name: "{{ item }}"
+      state: present
+      update_cache: "yes"
+    with_items: "{{ dependencies }}"
+    when: uninstall is undefined
+
+  - name: Clone the repo
+    git:
+      repo: "{{ repo }}"
+      version: "{{ ref }}"
+      dest: "{{ tmp_install_dir }}"
+
+  - name: Installation
+    block:
+    - name: Install recap
+      make:
+        chdir: "{{ tmp_install_dir }}"
+        target: install
+        params:
+          BINPATH: "{{ binpath }}"
+          DESTDIR: "{{ destdir }}"
+          PREFIX: "{{ prefix }}"
+
+    - name: Enable systemd timers
+      shell: >
+        systemctl enable recap.timer --now &&
+        systemctl enable recaplog.timer --now &&
+        systemctl enable recap-onboot.timer --now
+      when: ansible_service_mgr == 'systemd'
+
+    - name: Run manually recap
+      shell: >
+        recap &&
+        recap --version
+      register: recap_version
+
+    - name: Print recap version
+      debug:
+        var: recap_version.stdout_lines[0]
+    when: uninstall is undefined
+
+  - name: Uninstall
+    block:
+    # NOTE: this does not work with debian 8 due to systemd version
+    # not supporting '--now'
+    - name: Disable systemd timers
+      shell: >
+        systemctl disable recap.timer --now &&
+        systemctl disable recaplog.timer --now &&
+        systemctl disable recap-onboot.timer --now
+      when: ansible_service_mgr == 'systemd'
+
+    - name: Uninstall recap
+      make:
+        chdir: "{{ tmp_install_dir }}"
+        target: uninstall
+        params:
+          DESTDIR: "{{ destdir }}"
+          PREFIX: "{{ prefix }}"
+    when: uninstall is defined
+...


### PR DESCRIPTION
- Add ansible playbook to (un)install recap
- Documentation on how to use the playbook

This is helpful to make easier testing `recap` branches.