### PR TITLE
Make http_status (USEFULLSTATUS) a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Contribution guidelines can be found in [CONTRIBUTING.md](https://github.com/rac
 - grep
 - iotop
 - iproute/iproute2
-- links
+- elinks
 - procps
 - psmisc
 - sysstat >= 9
@@ -337,7 +337,7 @@ These are the type of reports generated and their dependencies.
 
 - **USERESOURCES** - Generates "resources"(uptime, free, vmstat, iostat, iotop) log
 
-  Required by: `USEDF`, `USESLAB`, `USESAR`, `USESARQ`, `USESARR`, `USEFULLSTATUS`
+  Required by: `USEDF`, `USESLAB`, `USESAR`, `USESARQ`, `USESARR`
 
   Default: `USERESOURCES="yes"`
 
@@ -375,12 +375,6 @@ These are the type of reports generated and their dependencies.
 
   Default: `USESARR="no"`
 
-- **USEFULLSTATUS** - Performs an http request(GET) to the URL defined in `OPTS_STATUSURL`. Needs a webserver configured to respond to this request. Nginx(nginx_status) and Apache HTTPD(server-stats) offer this functionality that needs to be enabled.
-
-  Requires: `USERESOURCES`
-
-  Default: `USEFULLSTATUS="no"`
-
 
 #### Options
 
@@ -397,11 +391,6 @@ Options used by the tools generating the reports
   Required by: `USEMYSQLPROCESSLIST`
 
   Default: `MYSQL_PROCESS_LIST="table"`
-
-- **OPTS_LINKS** - Options used by links.
-  Required by: `USEFULLSTATUS`
-
-  Default: `OPTS_LINKS="-dump"`
 
 - **OPTS_DF** - df options
 
@@ -457,12 +446,6 @@ Options used by the tools generating the reports
 
   Default: `OPTS_PSTREE="-p"`
 
-
-- **OPTS_STATUSURL** - URL to perform the http request  when USEFULLSTATUS is enabled.
-
-  Required by: `USEFULLSTATUS`
-
-  Default: `OPTS_STATUSURL="http://localhost:80/server-status"`
 
 - **OPTS_VMSTAT** - vmstat options
 

--- a/src/core/resources
+++ b/src/core/resources
@@ -83,15 +83,6 @@ print_sar() {
   log INFO "Ended 'sar' report"
 }
 
-# Print the output of the web server status page to the specified file
-print_http_fullstatus() {
-  local LOGFILE="$1"
-  log INFO "Starting 'web status page' report - ${LOGFILE##*/}"
-  echo "Web Status report" >> "${LOGFILE}"
-  links ${OPTS_LINKS} "${OPTS_STATUSURL}" 2>/dev/null >> "${LOGFILE}"
-  log INFO "Ended 'web status page' report"
-}
-
 # Print the disk utilization to the defined file
 print_df() {
   local LOGFILE="$1"

--- a/src/plugins/http_status
+++ b/src/plugins/http_status
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+#   Copyright (C) 2017 Rackspace, Inc.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#
+
+# Performs an http request(GET) to the defined URL
+
+print_http_status() {
+  local LOGFILE="$1"
+  local plugin_name=${FUNCNAME[0]/print_/}
+  log INFO "Starting '${plugin_name}' report - ${LOGFILE##*/}"
+  ##
+  # Default settings:
+  local default_args='-dump'
+  local default_timeout=5
+  local default_url='http://localhost:80/server-status'
+
+  # These values can be overriden in the config file, Examples:
+  # PLUGIN_OPTS_HTTP_STATUS_ARGS='-dump -dump-width 90 -dump-charset iso-8859-2'
+  # PLUGIN_OPTS_HTTP_STATUS_URL='http://localhost/nginx_status'
+  local http_status_args=${PLUGIN_OPTS_HTTP_STATUS_ARGS:-${default_args}}
+  local http_status_url=${PLUGIN_OPTS_HTTP_STATUS_URL:-${default_url}}
+
+  # Check if html dump tool is available
+  http_tool=$( type -p elinks )
+  if [[ -z ${http_tool} ]]; then
+    echo "elinks is not installed" >> "${LOGFILE}"
+    log INFO "Ended '${plugin_name}' report"
+    return
+  fi
+
+  timeout ${default_timeout} \
+    ${http_tool} \
+      ${http_status_args} \
+      "${http_status_url}" \
+      2>/dev/null >> "${LOGFILE}"
+
+  ##
+  log INFO "Ended '${plugin_name}' report"
+}

--- a/src/recap
+++ b/src/recap
@@ -70,12 +70,10 @@ declare -r default_USERESOURCES="yes"
 USERESOURCES="${default_USERESOURCES}"
 # These depend on USERRESOURCES to be enabled("yes")
 declare -r default_USEDF="yes"
-declare -r default_USEFULLSTATUS="no"
 declare -r default_USESAR="yes"
 declare -r default_USESARQ="no"
 declare -r default_USESARR="no"
 USEDF="${default_USEDF}"
-USEFULLSTATUS="${default_USEFULLSTATUS}"
 USESAR="${default_USESAR}"
 USESARQ="${default_USESARQ}"
 USESARR="${default_USESARR}"
@@ -101,7 +99,6 @@ USEINNODB="${default_USEINNODB}"
 USEMYSQLPROCESSLIST="${default_USEMYSQLPROCESSLIST}"
 
 # Default command options(can be overriden in config file)
-declare -r default_OPTS_LINKS="-dump"
 declare -r default_OPTS_DF="-x nfs"
 declare -r default_OPTS_FDISK="-l"
 declare -r default_OPTS_FREE=""
@@ -112,8 +109,6 @@ declare -r default_OPTS_NETSTAT_SUM="-a"
 declare -r default_OPTS_PS="auxfww"
 declare -r default_OPTS_PSTREE="-p"
 declare -r default_OPTS_VMSTAT="-S M 1 3"
-declare -r default_OPTS_STATUSURL="http://localhost:80/server-status"
-OPTS_LINKS="${default_OPTS_LINKS}"
 OPTS_DF="${default_OPTS_DF}"
 OPTS_FDISK="${default_OPTS_FDISK}"
 OPTS_FREE="${default_OPTS_FREE}"
@@ -124,7 +119,6 @@ OPTS_NETSTAT_SUM="${default_OPTS_NETSTAT_SUM}"
 OPTS_PS="${default_OPTS_PS}"
 OPTS_PSTREE="${default_OPTS_PSTREE}"
 OPTS_VMSTAT="${default_OPTS_VMSTAT}"
-OPTS_STATUSURL="${default_OPTS_STATUSURL}"
 
 # Internal variables
 banner_start="--- Starting $( basename $0 )[$$] ---"
@@ -327,13 +321,6 @@ run_resources_report() {
     # send sar -q output to output file
     print_blankline "${ITEM_FILE}"
     print_sar "${ITEM_FILE}" "q"
-  fi
-
-  # check to see if webserver fullstatus should be run
-  type -p 'links' > /dev/null
-  if [[ $? -eq 0 && "${USEFULLSTATUS,,}" == "yes" ]]; then
-    print_blankline "${ITEM_FILE}"
-    print_http_fullstatus "${ITEM_FILE}"
   fi
 
   if [[ "${USEDF,,}" == "yes" ]]; then

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -100,7 +100,7 @@
 
 ## Report: resources
 # USERESOURCES - Generates "resources"(uptime, free, vmstat, iostat, iotop) log
-# Required by: USEDF, USESLAB, USESAR, USESARQ, USESARR, USEFULLSTATUS
+# Required by: USEDF, USESLAB, USESAR, USESARQ, USESARR
 # Example, to disable: USERESOURCES="no"
 #USERESOURCES="yes"
 
@@ -130,14 +130,6 @@
 # Example, to enable: USESARR="yes"
 #USESARR="no"
 
-# USEFULLSTATUS - Performs an http request(GET) to the URL defined in
-# OPTS_STATUSURL. Needs a webserver configured to respond to this request.
-# Nginx(nginx_status) and Apache HTTPD(server-stats) offer this functionality
-# that needs to be enabled.
-# requires: USERESOURCES
-# Example, to enable: USEFULLSTATUS="yes"
-#USEFULLSTATUS="no"
-
 # USEPLUGINS - Enables the use of plugins, loaded from LIBDIR/plugins-enabled
 # Example, to enable: USEPLUGINS="yes"
 #USEPLUGINS="no"
@@ -158,11 +150,6 @@
 # Required by: USEMYSQLPROCESSLIST
 # Example, generate vertical output: MYSQL_PROCESS_LIST="vertical"
 #MYSQL_PROCESS_LIST="table"
-
-# OPTS_LINKS- Options used by links, when using USEFULLSTATUS
-# Required by: USEFULLSTATUS
-# Example: OPTS_LINKS="-dump -width 120 -codepage iso-8859-2"
-#OPTS_LINKS="-dump"
 
 # OPTS_DF - df options
 # Required by: USEDF
@@ -210,12 +197,6 @@
 # Required by: USEPSTREE
 # Example: OPTS_PSTREE="-cApu"
 #OPTS_PSTREE="-p"
-
-# OPTS_STATUSURL - URL to perform the http request  when USEFULLSTATUS is
-# enabled
-# Required by: USEFULLSTATUS
-# Example: OPTS_STATUSURL="http://localhost/nginx_status"
-#OPTS_STATUSURL="http://localhost:80/server-status"
 
 # OPTS_VMSTAT - vmstat options
 # Required by: USERESOURCES

--- a/src/recaplog
+++ b/src/recaplog
@@ -89,7 +89,7 @@ delete_old_logs() {
   matched_files=$(
     find "${BASEDIR}" -maxdepth 2 -regextype posix-extended \
       -type f -mtime +${LOG_EXPIRY} -regex \
-      "^${BASEDIR}/(.*/)?[a-z]+_([a-z]+_)?[0-9]{8}(-[0-9]{6})?\.log(\.tar)?(\.gz)?$"
+      "^${BASEDIR}/(.*/)?[a-z]+_([a-z]+_)*[0-9]{8}(-[0-9]{6})?\.log(\.tar)?(\.gz)?$"
   )
   if [[ -n "${matched_files}" ]]; then
     count_files=$( wc -l <<<"${matched_files}" )

--- a/tools/ansible_recap.yml
+++ b/tools/ansible_recap.yml
@@ -23,7 +23,7 @@
         - grep
         - iotop
         - "iproute{{'2' if ansible_os_family is match('Debian|Archlinux') else ''}}"
-        - links
+        - elinks
         - "{{ 'procps-ng' if ansible_os_family is match('Archlinux') else 'procps' }}"
         - psmisc
         - sysstat


### PR DESCRIPTION
- Move http_status report out of `resources` report.
- Adjust  `recaplog` to find logs of the form `name_(subname_)*_<date>`.
- Remove `USEFULLSTATUS` from `recap.conf`
- Replace **links** with **elinks** to reduce dependencies.

Important notes about the functional changes:
- Prior to this change  `USEFULLSTATUS` now `http_status` was disabled by default.
  - Now `http_status` is a plugin, hence is disabled by default.
- The reports of `http_status` were generated in the `resources` report, now generates its own report as any other plugin.
- Configuration examples in `recap.conf` have been removed, any modification to the default configurations for this `http_status` plugin will need to be added, this is true for any other plugin.

Notes on upgrade and versioning:
- This change is targeted for a newer major version of `recap` (2.0.0), per [Versioning](https://github.com/rackerlabs/recap#versioning) notes, this is a major change that will not be backward compatible.
- When upgrading, if the previous configuration had `USEFULLSTATUS` enabled, the behaviour will change since:
  1. The enable plugin option in `recap.conf` is disabled by default
  1. The plugin to generate reports needs to be enabled.
  This implies that it will be required to enable plugins and the `http_status` plugin itself. 
- Similarly if there is any configuration change to the previous `USEFULLSTATUS` options those will need to be re-added to the `recap.conf` with the new valid names

---
Fix #170, Fix #169 