### PR TITLE
Remove the warning messages on old config files.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -528,23 +528,7 @@ log INFO "${banner_start}"
 log INFO "-- bash info: ${BASH_VERSINFO[@]}"
 
 # Check for the configuration file.
-# The following creates awareness about the old config location in
-# /etc/recap, taking precedence the new config location /etc/recap.conf.
-if [[ -r /etc/recap &&
-      -r /etc/recap.conf ]]; then
-  log WARNING "Configuration files exist at old(/etc/recap) and"\
-              "new(/etc/recap.conf) locations. The file from the new"\
-              "location will be used."
-  log WARNING "Please move any missing configuration to /etc/recap.conf."
-  source /etc/recap.conf
-elif [[ -r /etc/recap &&
-        ! -r /etc/recap.conf ]]; then
-  log WARNING "Configuration file exists at old(/etc/recap) location."\
-              "The file will be read."\
-              "Please move your configuration file to /etc/recap.conf."\
-              "Next version of recap will not read /etc/recap"
-  source /etc/recap
-elif [[ ! -r /etc/recap.conf ]]; then
+if [[ ! -r /etc/recap.conf ]]; then
   log WARNING "No configuration file found. Expecting /etc/recap.conf."
   log WARNING "Proceeding with defaults."
 else

--- a/src/recap.8
+++ b/src/recap.8
@@ -45,7 +45,6 @@ Print version and exit.
 .nf
 /etc/recap.conf
 /etc/cron.d/recap
-/etc/recap
 /usr/lib/systemd/system/recap.{service,timer} - Unit files for running recap periodically.
 /usr/lib/systemd/system/recap-onboot.{service,timer} - Unit files for running recap on boot.
 

--- a/src/recaplog
+++ b/src/recaplog
@@ -290,23 +290,7 @@ fi
 log INFO "${banner_start}"
 
 # Check for the configuration file.
-# The following creates awareness about the old config location in
-# /etc/recap, taking precedence the new config location /etc/recap.conf.
-if [[ -r /etc/recap &&
-      -r /etc/recap.conf ]]; then
-  log WARNING "Configuration files exist at old(/etc/recap) and"\
-              "new(/etc/recap.conf) locations. The file from the new"\
-              "location will be used."
-  log WARNING "Please move any missing configuration to /etc/recap.conf."
-  source /etc/recap.conf
-elif [[ -r /etc/recap &&
-        ! -r /etc/recap.conf ]]; then
-  log WARNING "Configuration file exists at old(/etc/recap) location."\
-              "The file will be read."\
-              "Please move your configuration file to /etc/recap.conf."\
-              "Next version of recap will not read /etc/recap"
-  source /etc/recap
-elif [[ ! -r /etc/recap.conf ]]; then
+if [[ ! -r /etc/recap.conf ]]; then
   log WARNING "No configuration file found. Expecting /etc/recap.conf."
   log WARNING "Proceeding with defaults."
 else

--- a/src/recaplog.8
+++ b/src/recaplog.8
@@ -59,7 +59,7 @@ These can be modified via the config file.
 
 .SH FILES
 .nf
-/etc/recap - The configuration file.
+/etc/recap.conf - The configuration file.
 /etc/cront.d/recap - The cronjob file.
 /usr/lib/systemd/systemd/recaplog.{service,timer} - Unit files for recaplog.
 /var/log/recap/recaplog.log - The recaplog file.


### PR DESCRIPTION
This is the last change to complete #80 

On the last release [1.4.0](https://github.com/rackerlabs/recap/releases/tag/1.4.0):
  - We issue a warning when old `/etc/recap` was found, but `/etc/recap.conf` takes precedence.

Following the plan(https://github.com/rackerlabs/recap/pull/137#issuecomment-344661204) This PR is focusing on the goals of what was expected to be **1.5.0**, but we will not release **1.5.0**, instead we will release **2.0.0** the logic is then:

  - If no config is found a warning is logged, defaults are used.
  - If `/etc/recap.conf` is found then is read.

---
### Version 1.4.0 will shows:

- Both configs found, new one takes precedence:
```log
2018-12-26 10:58:48-06:00 [WARNING] Configuration files exist at old(/etc/recap) and new(/etc/recap.conf) locations. The file from the new location will be used.
2018-12-26 10:58:48-06:00 [WARNING] Please move any missing configuration to /etc/recap.conf.
```

- Only old config is found:
```log
2018-12-26 11:03:51-06:00 [WARNING] Configuration file exists at old(/etc/recap) location. The file will be read. Please move your configuration file to /etc/recap.conf. Next version of recap will not read /etc/recap
```

- No config is found:
```log
2018-12-26 11:04:26-06:00 [WARNING] No configuration file found. Expecting /etc/recap.conf.
2018-12-26 11:04:26-06:00 [WARNING] Proceeding with defaults.
```

- No warning is logged when only new config is found

### Version 2.0.0 (this PR) will show:

- Both configs (old `/etc/recap` and `/etc/recap.conf`) in place, former is ignored, latter is read, no warnings logged.

- No warning is logged when the valid config `/etc/recap.conf` is found

- No config is found:
```log
2018-12-26 11:13:05-06:00 [WARNING] No configuration file found. Expecting /etc/recap.conf.
2018-12-26 11:13:05-06:00 [WARNING] Proceeding with defaults.
```

