### PR TITLE
List plugins instead of expand them.

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -252,7 +252,7 @@ plugins_info(){
 plugins_load() {
   local plugin_dir="$1"
   log INFO "Loading plugins from: ${plugin_dir}"
-  for plugin in "${plugin_dir}"/*; do
+  for plugin in $( ls -1 "${plugin_dir}" ); do
     log INFO "Loading plugin: ${plugin}"
     source ${plugin}
   done

--- a/src/recap
+++ b/src/recap
@@ -252,10 +252,10 @@ plugins_info(){
 plugins_load() {
   local plugin_dir="$1"
   log INFO "Loading plugins from: ${plugin_dir}"
-  for plugin in $( ls -1 "${plugin_dir}" ); do
+  while read plugin; do
     log INFO "Loading plugin: ${plugin}"
-    source ${plugin}
-  done
+    source "${plugin_dir}/${plugin}"
+  done < <(ls -1 "${plugin_dir}" 2>/dev/null)
 }
 
 # Load core functions


### PR DESCRIPTION
This fixes #183  Instead of expanding through globbing it lists the content of the `plugins_dir`, displaying the proper warning when there's none.

```log
2018-12-26 12:06:03-06:00 [WARNING] No plugins found to execute in: /usr/local/lib/recap/plugins-enabled
```