### PR TITLE
Do not add DESTDIR to recap script on install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ uninstall: uninstall-base uninstall-man uninstall-doc uninstall-$(type)
 
 install-base:
 	@echo "Installing scripts..."
-	@sed -i.orig 's|^\s*\(declare\s\+-r\s\+LIBDIR=\).*$$|\1"$(DESTDIR)$(LIBDIR)/recap"|' src/recap
+	@sed -i.orig 's|^\s*\(declare\s\+-r\s\+LIBDIR=\).*$$|\1"$(LIBDIR)/recap"|' src/recap
 	@install -Dm0755 src/recap $(DESTDIR)$(BINDIR)/recap
 	@install -Dm0755 src/recaplog $(DESTDIR)$(BINDIR)/recaplog
 	@install -Dm0755 src/recaptool $(DESTDIR)$(BINDIR)/recaptool


### PR DESCRIPTION
By this change the functionality of `DESTDIR` is guaranteed for packaging or troubleshooting purposes **only**.

It is **not expected** that `recap` will work for normal operations when **DESTDIR** is defined when installing. This is due to the fact that **LIBDIR** variable inside `recap` will not make use of **DESTDIR** value, instead use the value of **LIBDIR** (from the Makefile or through environment).

---

> _DESTDIR support is commonly used in package creation. It is also helpful to users who want to understand what a given package will install where, and to allow users who don’t normally have permissions to install into protected areas to build and install before gaining those permissions._ 

[1] https://www.gnu.org/software/make/manual/html_node/DESTDIR.html

---

This change keeps the reference of `LIBDIR` in `recap` ignoring `DESTIDIR`:
```bash
$ make DESTDIR=/home/tonyskapunk/rpm/BUILDROOT/ PREFIX=/usr install -n | grep LIBDIR
sed -i.orig 's|^\s*\(declare\s\+-r\s\+LIBDIR=\).*$|\1"/usr/lib/recap"|' src/recap

```

Fix #195 