### PR TITLE
Use posix for better regex support in el6

### DIFF
--- a/src/recaplog
+++ b/src/recaplog
@@ -133,7 +133,7 @@ get_report_names_of_day() {
   log INFO "Finding reports from: ${day}"
   reports=(
     $( ls -1 "${BASEDIR}" 2>/dev/null |
-         awk -F. \
+         awk --posix -F. \
          '
            /'${day}'-[0-9]{6}\.log$/ {sub("_'${day}'-[0-9]{6}","",$1); print $1}
          ' |


### PR DESCRIPTION
This is required on el6 otherwise the interval  expressions `{}` were not honoured. Fix #207 