### PR TITLE
Add fedora distro for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,12 @@ matrix:
     - name: "Debian (buster)"
       env:
         - DISTRO='debian:buster'
+    - name: "Fedora (latest)"
+      env:
+        - DISTRO='fedora:latest'
+    - name: "Fedora (rawhide)"
+      env:
+        - DISTRO='fedora:rawhide'
 
 before_install:
   - docker pull ${DISTRO}

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -16,7 +16,7 @@ packages=(
           )
 
 case ${DISTRO} in
-  centos*)
+  centos*|fedora*)
     packages+=("iproute")
     yum install ${packages[@]} -y || exit $?
     ;;


### PR DESCRIPTION
Adding Fedora distros for testing:
- latest (currently 29)
- rawhide (currently 31)