### PR TITLE
Hostname

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -549,6 +549,13 @@ HOSTNAME="$( hostnamectl --static 2>/dev/null ||
              hostname 2>/dev/null ||
              echo 'Unknown' )"
 
+# Workaround for ubuntu14 as --static has no effect when printing values
+if grep -q 'hostname:' <<<"${HOSTNAME}"; then
+  HOSTNAME=$( awk -F: \
+              '/hostname/ {gsub("\\s*","",$2)
+              print $2}' <<<"${HOSTNAME}" )
+fi
+
 # Start logging
 log INFO "${banner_start}"
 log INFO "-- bash info: ${BASH_VERSINFO[@]}"

--- a/src/recap
+++ b/src/recap
@@ -545,7 +545,9 @@ if [[ "$(id -u)" != "0" ]]; then
 fi
 
 # Grab the server's host name
-HOSTNAME="$( hostname )"
+HOSTNAME="$( hostnamectl --static 2>/dev/null ||
+             hostname 2>/dev/null ||
+             echo 'Unknown' )"
 
 # Start logging
 log INFO "${banner_start}"


### PR DESCRIPTION
Through attempting to add fedora in #211 it was found (through a couple of builds [here](https://travis-ci.org/rackerlabs/recap/jobs/519364090#L634) and [here](https://travis-ci.org/rackerlabs/recap/jobs/519364091#L628)) that the binary `hostname` requires `hostname` package to be installed, to avoid having that dependency I'm defaulting to use `hostnamectl`, falling back to `hostname`, ultimately setting a default value.

Through testing it was found that ubuntu14 is not displaying correctly `hostnamectl` functionality, so another workaround was added to it, despite u14 is EOL in a few days.