### PR TITLE
Add CLI plugins to recap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,13 @@ script:
   - docker exec recap_on_${DISTRO/:/_} bash -c 'ls -tr /var/log/recap/*log | xargs tail -v -n+0'
   - docker exec recap_on_${DISTRO/:/_} /recap/tests/run_recaplog.sh
   - docker exec recap_on_${DISTRO/:/_} bash -c 'tail -v -n+0 /var/log/recap/recaplog.log'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list enabled'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p enable all'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list enabled'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list disabled'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p disable all'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list disabled'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recap -p list enabled'
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 - Modify iotop default [#218][218]
+- Add plugin cli support to `recap` [#217][217]
 
 ## [2.1.0] - 2019-04-12
 - Remove signal `17` in `recaplog` [(#208)][208]
@@ -227,6 +228,7 @@ All notable changes to this project will be documented in this file.
 [207]: https://github.com/rackerlabs/recap/issues/207
 [208]: https://github.com/rackerlabs/recap/issues/208
 [213]: https://github.com/rackerlabs/recap/pull/213
+[217]: https://github.com/rackerlabs/recap/issues/217
 [218]: https://github.com/rackerlabs/recap/issues/218
 
 <!---

--- a/src/core/plugins
+++ b/src/core/plugins
@@ -25,9 +25,9 @@ in_array() {
   local element="${1}"
   shift
   local -a array=( ${@} )
-  
+
   # Copy the array, removing the element
-  c_array=( ${array[@]//${element}} )
+  local -a c_array=( ${array[@]//${element}} )
 
   # If the arrays are the same, the element is not part of the array
   if [[ ${#array[@]} == ${#c_array[@]} ]]; then
@@ -37,8 +37,8 @@ in_array() {
   fi
 }
 
-# Removes dups from a csv string
-csv_remove_dups() {
+# Transforms a csv into a space-separated list, also removs dups
+csv_to_list() {
   local csv="${1}"
   local -a array
 
@@ -57,8 +57,8 @@ plugins_list() {
   echo ${p_names[@]}
 }
 
-# Validate action (list, enable, disable)
-plugin_validate_action() {
+# Validate plugin action (list, enable, disable)
+validate_plugin_action() {
   case "${1}" in
     "list"|"enable"|"disable")
       return 0
@@ -69,8 +69,20 @@ plugin_validate_action() {
   esac
 }
 
-# Obtain a list of plugin by status
-get_plugin_status() {
+# Validate plugin status (available, enabled, disabled)
+validate_plugin_status() {
+  case "${1}" in
+    "available"|"enabled"|"disabled")
+      return 0
+    ;;
+    *)
+      return 1
+    ;;
+  esac
+}
+
+# Obtain a list of plugins by status
+get_plugin_by_status() {
   local list_status="${1}"
   local -a plugins
 
@@ -84,49 +96,23 @@ get_plugin_status() {
     "disabled")
       plugins_a=( $( plugins_list "${PLUGIN_A_DIR}" ) )
       plugins_e=( $( plugins_list "${PLUGIN_E_DIR}" ) )
-      # Loop through the available plugins
-      for p_a in ${plugins_a[@]}; do
-        # Copy the list of enabled plugins removing the available in turn
-        c_p_e=( ${plugins_e[@]//${p_a}} )
-        # If both arrays are the same then the looped plugin is disabled
-        if [[ ${#plugins_e[@]} == ${#c_p_e[@]} ]]; then
-            plugins+=( ${p_a} )
-        fi
-      done
+      # Get disabled plugins (available but not enabled)
+      plugins=(
+        $( comm \
+             -23 \
+             <( printf "%s\n" "${plugins_a[@]}" ) \
+             <( printf "%s\n" "${plugins_e[@]}" ) |
+               tr '\n' ' '
+        )
+      )
     ;;
   esac
 
   echo "${plugins[@]}"
 }
 
-# Prints the status of plugins
-print_plugins() {
-  local list_status="${1}"
-  local plugins
-
-  case "${list_status}" in
-    "available"|"enabled"|"disabled")
-      plugins=$( get_plugin_status "${list_status}" )
-    ;;
-    *)
-      echo -e "Error: Invalid list status argument: ${list_status}\n" >&2
-      print_usage
-      return 1
-    ;;
-  esac
-
-  if [[ ${#plugins} == 0 ]]; then
-    log ERROR "No ${list_status} plugins found."
-  else
-    plugins=$( echo "${plugins[@]}" | tr " " "," )
-    echo "Plugins ${list_status}: ${plugins%,}"
-    log INFO "Plugins ${list_status}: ${plugins%,}"
-  fi
-  return 0
-}
-
-# Validate plugin names. "all" is valid (represent all available)
-validate_plugin() {
+# Validate plugin name. "all" is valid (represent all available)
+validate_plugin_name() {
   local plugins="$1"
   local -a plugins_a
 
@@ -134,13 +120,13 @@ validate_plugin() {
   if [[ "${plugins}" == "all" ]]; then
     return 0
   fi
-  
+
   # Getting the list of available plugins
-  plugins_a=( $( get_plugin_status "available" ) )
+  plugins_a=( $( get_plugin_by_status "available" ) )
 
   # Create array with the provided plugins, remove dups
-  local -a p_v=( $( csv_remove_dups "${plugins}" ) )
-  
+  local -a p_v=( $( csv_to_list "${plugins}" ) )
+
   # Validate provided plugin with available
   for p in ${p_v[@]}; do
     if ! in_array ${p} ${plugins_a[@]}; then
@@ -155,45 +141,69 @@ validate_plugin() {
 enable_plugin_conf() {
    local recap_conf="/etc/recap.conf"
 
-   # Only perform changes when not already defined
-   if [[ "${USEPLUGINS}" == "no" ]]; then
-     # Comment out explicitly disabled
-     if grep -q '^USEPLUGINS="no"' "${recap_conf}"; then
-        sed -i \
-          -e 's/^\(USEPLUGINS="no"*\)$/#\1/' \
-          "${recap_conf}"
-     fi
-     # Comment out all explicitly enabled, we enable them next
-     # This is to remove dups
-     if grep -q '^USEPLUGINS="yes"' "${recap_conf}"; then
-        sed -i \
-          -e 's/^\(USEPLUGINS="yes"*\)$/#\1/' \
-          "${recap_conf}"
-     fi
-
-     # Un-comment out if enabling is commented out
-     if grep -P -q '^#+USEPLUGINS="yes"' "${recap_conf}"; then
-        sed -E -i \
-          -e '0,/^#+USEPLUGINS="yes"/s//USEPLUGINS="yes"/' \
-          "${recap_conf}"
-
-     # Add after the first reference commented out
-     elif grep -P -q '^#+USEPLUGINS="no"' "${recap_conf}"; then
-        sed -E -i \
-          -e '0,/^#+USEPLUGINS="no"/{
-	       /^#+USEPLUGINS="no"/a USEPLUGINS="yes"
-	  }' "${recap_conf}"
-
-     # Add at the end, as no traces have been found
-     # Using sed, just to keep it consistent
-     else
-        sed -i \
-	  -e '$ a\#USEPLUGINS="no"\nUSEPLUGINS="yes"' \
-          "${recap_conf}"
-     fi
-     log INFO "Plugins enabled in ${recap_conf}"
+   # Do nothing if already enabled
+   if [[ "${USEPLUGINS}" == "yes" ]]; then
+     return
    fi
+
+   # Comment out explicitly disabled
+   if grep -q '^USEPLUGINS="no"' "${recap_conf}"; then
+      sed -i \
+        -e 's/^\(USEPLUGINS="no"*\)$/#\1/' \
+        "${recap_conf}"
+   fi
+   # Comment out all explicitly enabled, we enable them next
+   # This is to remove dups
+   if grep -q '^USEPLUGINS="yes"' "${recap_conf}"; then
+      sed -i \
+        -e 's/^\(USEPLUGINS="yes"*\)$/#\1/' \
+        "${recap_conf}"
+   fi
+
+   # Un-comment out if enabling is commented out
+   if grep -P -q '^#+USEPLUGINS="yes"' "${recap_conf}"; then
+      sed -E -i \
+        -e '0,/^#+USEPLUGINS="yes"/s//USEPLUGINS="yes"/' \
+        "${recap_conf}"
+
+   # Add after the first reference commented out
+   elif grep -P -q '^#+USEPLUGINS="no"' "${recap_conf}"; then
+      sed -E -i \
+        -e '0,/^#+USEPLUGINS="no"/{
+         /^#+USEPLUGINS="no"/a USEPLUGINS="yes"
+    }' "${recap_conf}"
+
+   # Add at the end, as no traces have been found
+   # Using sed, just to keep it consistent
+   else
+      sed -i \
+    -e '$ a\#USEPLUGINS="no"\nUSEPLUGINS="yes"' \
+        "${recap_conf}"
+   fi
+   log INFO "Plugins enabled in ${recap_conf}"
 }
+
+# Enable Plugin
+enable_plugin() {
+  local plugin="${1}"
+  local symlink="${PLUGIN_E_DIR}/${plugin}"
+  local target="../$( basename ${PLUGIN_A_DIR} )/${plugin}"
+  {
+    ln -s "${target}" "${symlink}" ||
+      exit 1
+  }
+}
+
+# Disable Plugin
+disable_plugin() {
+  local plugin="${1}"
+  local symlink="${PLUGIN_E_DIR}/${plugin}"
+  {
+    rm "${symlink}" ||
+      exit 1
+  }
+}
+
 
 # Plugin Enable/Disable
 plugin_action() {
@@ -205,44 +215,36 @@ plugin_action() {
   other_action=( ${other_action[@]//${action}} )
 
   # Get plugins (disabled or enabled)
-  local p_a=( $( get_plugin_status "${other_action}d" ) )
+  local p_a=( $( get_plugin_by_status "${other_action}d" ) )
 
   # Cleanup provided plugins or get "all" plugins
   local -a p_2a
   local -a actioned
   if [[ "${plugins}" == "all" ]]; then
-    p_2a=( $( get_plugin_status "available" ) )
+    p_2a=( $( get_plugin_by_status "available" ) )
   else
-    p_2a=( $( csv_remove_dups "${plugins}" ) )
+    p_2a=( $( csv_to_list "${plugins}" ) )
   fi
 
   # Enable or disable plugins that are currently disabled or enabled
   for plugin in ${p_2a[@]}; do
     if in_array ${plugin} ${p_a[@]}; then
-      local symlink="${PLUGIN_E_DIR}/${plugin}"
-
       # Enable disabled plugin
       if [[ "${action}" == "enable" ]]; then
-        local target="../$( basename ${PLUGIN_A_DIR} )/${plugin}"
-        {
-          ln -s "${target}" "${symlink}" ||
-            exit 1
-        }
-
+        enable_plugin "${plugin}"
       # Disable enabled plugin
       elif [[ "${action}" == "disable" ]]; then
-        {
-          rm "${symlink}" ||
-            exit 1
-        }
+        disable_plugin "${plugin}"
       fi
-      actioned+=( ${plugin} )
+      actioned+=( "${plugin}" )
+    else
+      log INFO "Plugin ${plugin} skipped, already ${action}d."
     fi
   done
 
-  # Print what plugins where enabled/disabled if needed
+  # Print what plugins were enabled/disabled if needed
   if [[ ${#actioned[@]} > 0 ]]; then
-    actioned=$( echo ${actioned[@]} |tr ' ' ',' ) 
+    actioned=$( echo ${actioned[@]} |tr ' ' ',' )
     echo "${action^}d: ${actioned}"
     log INFO "${action^}d: ${actioned}"
   else
@@ -264,18 +266,32 @@ plugin_cli_action() {
     "list")
       # Get list of plugins, default to available
       local list_status=${opt:-available}
-      if ! print_plugins "${list_status}"; then
+
+      # Validate plugin status given
+      if ! validate_plugin_status "${list_status}"; then
+        echo -e "Error: Invalid plugin status\n" >&2
+        print_usage
         exit 1
+      fi
+
+      local -a plugins=( $( get_plugin_by_status "${list_status}") )
+
+      if [[ ${#plugins[@]} == 0 ]]; then
+        log ERROR "No ${list_status} plugins found."
+      else
+        plugins=$( echo "${plugins[@]}" | tr " " "," )
+        echo "Plugins ${list_status}: ${plugins%,}"
+        log INFO "Plugins ${list_status}: ${plugins%,}"
       fi
     ;;
     "enable"|"disable")
-      # Validate list of given plugins
-      if ! validate_plugin "${opt}"; then
+      # Validate plugin name given
+      if ! validate_plugin_name "${opt}"; then
         log ERROR "Invalid list of plugins provided"
         exit 1
       fi
 
-      plugin_action "${action}" "${opt}" 
+      plugin_action "${action}" "${opt}"
     ;;
   esac
 }

--- a/src/core/plugins
+++ b/src/core/plugins
@@ -1,0 +1,306 @@
+#!/bin/bash
+#
+#   Copyright (C) 2017 Rackspace, Inc.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#
+
+## Helper functions for array  manipulation
+
+# Find element in an array
+in_array() {
+  local element="${1}"
+  shift
+  local -a array=( ${@} )
+  
+  # Copy the array, removing the element
+  c_array=( ${array[@]//${element}} )
+
+  # If the arrays are the same, the element is not part of the array
+  if [[ ${#array[@]} == ${#c_array[@]} ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+# Removes dups from a csv string
+csv_remove_dups() {
+  local csv="${1}"
+  local -a array
+
+  array=$( echo "${csv}" | tr ',' '\n' | sort -u | tr '\n' ' ' )
+  array=( ${array% } )
+  echo ${array[@]}
+}
+
+
+## Helper functions for plugin cli actions
+
+# Obtain the list of plugins in a directory
+plugins_list() {
+  local plugin_dir="$1"
+  local p_names=( $( ls -1 "${plugin_dir}" | tr '\n' ' ') )
+  echo ${p_names[@]}
+}
+
+# Validate action (list, enable, disable)
+plugin_validate_action() {
+  case "${1}" in
+    "list"|"enable"|"disable")
+      return 0
+    ;;
+    *)
+      return 1
+    ;;
+  esac
+}
+
+# Obtain a list of plugin by status
+get_plugin_status() {
+  local list_status="${1}"
+  local -a plugins
+
+  case "${list_status}" in
+    "available")
+      plugins+=( $( plugins_list "${PLUGIN_A_DIR}" ) )
+    ;;
+    "enabled")
+      plugins+=( $( plugins_list "${PLUGIN_E_DIR}" ) )
+    ;;
+    "disabled")
+      plugins_a=( $( plugins_list "${PLUGIN_A_DIR}" ) )
+      plugins_e=( $( plugins_list "${PLUGIN_E_DIR}" ) )
+      # Loop through the available plugins
+      for p_a in ${plugins_a[@]}; do
+        # Copy the list of enabled plugins removing the available in turn
+        c_p_e=( ${plugins_e[@]//${p_a}} )
+        # If both arrays are the same then the looped plugin is disabled
+        if [[ ${#plugins_e[@]} == ${#c_p_e[@]} ]]; then
+            plugins+=( ${p_a} )
+        fi
+      done
+    ;;
+  esac
+
+  echo "${plugins[@]}"
+}
+
+# Prints the status of plugins
+print_plugins() {
+  local list_status="${1}"
+  local plugins
+
+  case "${list_status}" in
+    "available"|"enabled"|"disabled")
+      plugins=$( get_plugin_status "${list_status}" )
+    ;;
+    *)
+      echo -e "Error: Invalid list status argument: ${list_status}\n" >&2
+      print_usage
+      return 1
+    ;;
+  esac
+
+  if [[ ${#plugins} == 0 ]]; then
+    log ERROR "No ${list_status} plugins found."
+  else
+    plugins=$( echo "${plugins[@]}" | tr " " "," )
+    echo "Plugins ${list_status}: ${plugins%,}"
+    log INFO "Plugins ${list_status}: ${plugins%,}"
+  fi
+  return 0
+}
+
+# Validate plugin names. "all" is valid (represent all available)
+validate_plugin() {
+  local plugins="$1"
+  local -a plugins_a
+
+  # Validate "all", it is not valid to combine "all" with other plugins
+  if [[ "${plugins}" == "all" ]]; then
+    return 0
+  fi
+  
+  # Getting the list of available plugins
+  plugins_a=( $( get_plugin_status "available" ) )
+
+  # Create array with the provided plugins, remove dups
+  local -a p_v=( $( csv_remove_dups "${plugins}" ) )
+  
+  # Validate provided plugin with available
+  for p in ${p_v[@]}; do
+    if ! in_array ${p} ${plugins_a[@]}; then
+        return 1
+    fi
+  done
+
+  return 0
+}
+
+# Enable Plugin support in recap.conf
+enable_plugin_conf() {
+   local recap_conf="/etc/recap.conf"
+
+   # Only perform changes when not already defined
+   if [[ "${USEPLUGINS}" == "no" ]]; then
+     # Comment out explicitly disabled
+     if grep -q '^USEPLUGINS="no"' "${recap_conf}"; then
+        sed -i \
+          -e 's/^\(USEPLUGINS="no"*\)$/#\1/' \
+          "${recap_conf}"
+     fi
+     # Comment out all explicitly enabled, we enable them next
+     # This is to remove dups
+     if grep -q '^USEPLUGINS="yes"' "${recap_conf}"; then
+        sed -i \
+          -e 's/^\(USEPLUGINS="yes"*\)$/#\1/' \
+          "${recap_conf}"
+     fi
+
+     # Un-comment out if enabling is commented out
+     if grep -P -q '^#+USEPLUGINS="yes"' "${recap_conf}"; then
+        sed -E -i \
+          -e '0,/^#+USEPLUGINS="yes"/s//USEPLUGINS="yes"/' \
+          "${recap_conf}"
+
+     # Add after the first reference commented out
+     elif grep -P -q '^#+USEPLUGINS="no"' "${recap_conf}"; then
+        sed -E -i \
+          -e '0,/^#+USEPLUGINS="no"/{
+	       /^#+USEPLUGINS="no"/a USEPLUGINS="yes"
+	  }' "${recap_conf}"
+
+     # Add at the end, as no traces have been found
+     # Using sed, just to keep it consistent
+     else
+        sed -i \
+	  -e '$ a\#USEPLUGINS="no"\nUSEPLUGINS="yes"' \
+          "${recap_conf}"
+     fi
+     log INFO "Plugins enabled in ${recap_conf}"
+   fi
+}
+
+# Plugin Enable/Disable
+plugin_action() {
+  local action="${1}"
+  local plugins="${2}"
+
+  # Get the other (opposite) action
+  local -a other_action=( "enable" "disable" )
+  other_action=( ${other_action[@]//${action}} )
+
+  # Get plugins (disabled or enabled)
+  local p_a=( $( get_plugin_status "${other_action}d" ) )
+
+  # Cleanup provided plugins or get "all" plugins
+  local -a p_2a
+  local -a actioned
+  if [[ "${plugins}" == "all" ]]; then
+    p_2a=( $( get_plugin_status "available" ) )
+  else
+    p_2a=( $( csv_remove_dups "${plugins}" ) )
+  fi
+
+  # Enable or disable plugins that are currently disabled or enabled
+  for plugin in ${p_2a[@]}; do
+    if in_array ${plugin} ${p_a[@]}; then
+      local symlink="${PLUGIN_E_DIR}/${plugin}"
+
+      # Enable disabled plugin
+      if [[ "${action}" == "enable" ]]; then
+        local target="../$( basename ${PLUGIN_A_DIR} )/${plugin}"
+        {
+          ln -s "${target}" "${symlink}" ||
+            exit 1
+        }
+
+      # Disable enabled plugin
+      elif [[ "${action}" == "disable" ]]; then
+        {
+          rm "${symlink}" ||
+            exit 1
+        }
+      fi
+      actioned+=( ${plugin} )
+    fi
+  done
+
+  # Print what plugins where enabled/disabled if needed
+  if [[ ${#actioned[@]} > 0 ]]; then
+    actioned=$( echo ${actioned[@]} |tr ' ' ',' ) 
+    echo "${action^}d: ${actioned}"
+    log INFO "${action^}d: ${actioned}"
+  else
+    echo "Plugins already ${action}d"
+    log INFO "Plugins already ${action}d"
+  fi
+
+  if [[ "${action}" == "enable" ]]; then
+    enable_plugin_conf
+  fi
+}
+
+# Plugin CLI action
+plugin_cli_action() {
+  local action="${1}"
+  local opt="${2}"
+
+  case "${action}" in
+    "list")
+      # Get list of plugins, default to available
+      local list_status=${opt:-available}
+      if ! print_plugins "${list_status}"; then
+        exit 1
+      fi
+    ;;
+    "enable"|"disable")
+      # Validate list of given plugins
+      if ! validate_plugin "${opt}"; then
+        log ERROR "Invalid list of plugins provided"
+        exit 1
+      fi
+
+      plugin_action "${action}" "${opt}" 
+    ;;
+  esac
+}
+
+## Helper functions to use plugins
+
+# Plugin info
+plugins_info(){
+  for dir in "${PLUGIN_A_DIR}" "${PLUGIN_E_DIR}"; do
+    log INFO "Finding plugins in ${dir}"
+    plugins=( $( plugins_list "${dir}" ) )
+    if [[ ${#plugins[@]} == 0 ]]; then
+      log INFO "No plugins found."
+    else
+      log INFO "${#plugins[@]} plugins found: ${plugins[@]}"
+    fi
+  done
+}
+
+# Loads plugins
+plugins_load() {
+  local plugin_dir="$1"
+  log INFO "Loading plugins from: ${plugin_dir}"
+  while read plugin; do
+    log INFO "Loading plugin: ${plugin}"
+    source "${plugin_dir}/${plugin}"
+  done < <(ls -1 "${plugin_dir}" 2>/dev/null)
+}

--- a/src/core/plugins
+++ b/src/core/plugins
@@ -139,48 +139,21 @@ validate_plugin_name() {
 
 # Enable Plugin support in recap.conf
 enable_plugin_conf() {
-   local recap_conf="/etc/recap.conf"
+  local recap_conf="/etc/recap.conf"
 
-   # Do nothing if already enabled
-   if [[ "${USEPLUGINS}" == "yes" ]]; then
-     return
-   fi
+  # If already enabled, just return:
+  [[ "${USEPLUGINS}" == "yes" ]] && return
 
-   # Comment out explicitly disabled
-   if grep -q '^USEPLUGINS="no"' "${recap_conf}"; then
-      sed -i \
-        -e 's/^\(USEPLUGINS="no"*\)$/#\1/' \
-        "${recap_conf}"
-   fi
-   # Comment out all explicitly enabled, we enable them next
-   # This is to remove dups
-   if grep -q '^USEPLUGINS="yes"' "${recap_conf}"; then
-      sed -i \
-        -e 's/^\(USEPLUGINS="yes"*\)$/#\1/' \
-        "${recap_conf}"
-   fi
+  # If config already mentions USEPLUGINS, ensure they're all commented:
+  if grep -qP '^\s*USEPLUGINS=' "${recap_conf}"; then
+    # Comment all of 'em:
+    sed -i '/^\s*USEPLUGINS=/^/#/' "${recap_conf}"
+  fi
 
-   # Un-comment out if enabling is commented out
-   if grep -P -q '^#+USEPLUGINS="yes"' "${recap_conf}"; then
-      sed -E -i \
-        -e '0,/^#+USEPLUGINS="yes"/s//USEPLUGINS="yes"/' \
-        "${recap_conf}"
+  # Add one entry at the bottom to enable USEPLUGINS:
+  echo 'USEPLUGINS="yes"' >> "${recap_conf}"
 
-   # Add after the first reference commented out
-   elif grep -P -q '^#+USEPLUGINS="no"' "${recap_conf}"; then
-      sed -E -i \
-        -e '0,/^#+USEPLUGINS="no"/{
-         /^#+USEPLUGINS="no"/a USEPLUGINS="yes"
-    }' "${recap_conf}"
-
-   # Add at the end, as no traces have been found
-   # Using sed, just to keep it consistent
-   else
-      sed -i \
-    -e '$ a\#USEPLUGINS="no"\nUSEPLUGINS="yes"' \
-        "${recap_conf}"
-   fi
-   log INFO "Plugins enabled in ${recap_conf}"
+  log INFO "Plugins enabled in ${recap_conf}"
 }
 
 # Enable Plugin

--- a/src/recap
+++ b/src/recap
@@ -19,10 +19,16 @@
 #
 #~ Usage: _tool_ [OPTION]
 #~ Options:
-#~   -h, --help       Print this help.
-#~   -B, --backup     Copy the last log file to the backups dir.
-#~   -S, --snapshot   Take a timestamped snapshot outside the regular rotation.
-#~   -V, --version    Print version and exit.
+#~   -h, --help              Print this help.
+#~   -B, --backup            Copy the last log file to the backups dir.
+#~   -p, --plugin [ACTIONS]  Perform plugin related actions.
+#~   -S, --snapshot          Take a snapshot in the snapshot dir.
+#~   -V, --version           Print version and exit.
+#~
+#~ Plugin Actions:
+#~  list [TYPE]           List 'available' (default),'enabled' or 'disabled' plugins
+#~  enable [NAME[,NAME]]  Enable a list of comma separated or 'all' plugins
+#~  disable [NAME[,NAME]] Disable a list of plugins (see: enable)
 #~
 
 ## Version
@@ -227,38 +233,8 @@ print_blankline() {
   echo " " >> "${LOGFILE}"
 }
 
-# Plugin names
-# Obtain the list of files/plugins on a directory
-plugins_list() {
-  local plugin_dir="$1"
-  local p_names=( $( ls -1 "${plugin_dir}" | tr '\n' ' ') )
-  echo ${p_names[@]}
-}
-
-# Plugin info
-plugins_info(){
-  for dir in "${PLUGIN_A_DIR}" "${PLUGIN_E_DIR}"; do
-    log INFO "Finding plugins in ${dir}"
-    plugins=( $( plugins_list "${dir}" ) )
-    if [[ ${#plugins[@]} == 0 ]]; then
-      log INFO "No plugins found."
-    else
-      log INFO "${#plugins[@]} plugins found: ${plugins[@]}"
-    fi
-  done
-}
-
-# Loads plugins
-plugins_load() {
-  local plugin_dir="$1"
-  log INFO "Loading plugins from: ${plugin_dir}"
-  while read plugin; do
-    log INFO "Loading plugin: ${plugin}"
-    source "${plugin_dir}/${plugin}"
-  done < <(ls -1 "${plugin_dir}" 2>/dev/null)
-}
-
 # Load core functions
+source ${COREDIR}/plugins
 source ${COREDIR}/ps
 source ${COREDIR}/fdisk
 source ${COREDIR}/mysql
@@ -477,11 +453,12 @@ check_disk_space() {
   log INFO "Ended check for disk space"
 }
 
+
 ## Main
 
 # Set options
-OPTIONS=VBhS
-LONG_OPTIONS=version,backup,help,snapshot
+OPTIONS=VBhSp:
+LONG_OPTIONS=version,backup,help,snapshot,plugin:
 
 # Parse options and show usage if invalid options provided
 ! ALL_ARGS=$(getopt --options=${OPTIONS} --longoptions=${LONG_OPTIONS} --name "$0" -- "$@")
@@ -491,11 +468,11 @@ if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
 fi
 
 # Set the positional parameters to the parsed options
-set -- ${ALL_ARGS}
+eval set -- "${ALL_ARGS}"
 
 # Act on the valid arguments provided
-while true; do
-  case "$1" in
+while [[ ${#} -gt 0 ]]; do
+  case "${1}" in
     -V|--version)
       echo "${_VERSION}"
       exit 0
@@ -509,6 +486,22 @@ while true; do
       # print usage
       print_usage
       exit 0
+      ;;
+    -p|--plugin)
+      # plugins actions
+      p_args=( ${*} )
+      shift ${#p_args[@]}
+
+      # Args come in the form: -p -- action options
+      PLUGIN_ACTION="${p_args[1]}"
+      PLUGIN_OPT="${p_args[@]:3}"
+
+      # Validate action
+      if ! plugin_validate_action "${PLUGIN_ACTION}"; then
+        echo -e "Error: Invalid plugin action\n" >&2
+        print_usage
+        exit 1
+      fi
       ;;
     -S|--snapshot)
       # take a snapshot outside of the regular output rotation
@@ -566,6 +559,13 @@ if [[ ! -r /etc/recap.conf ]]; then
   log WARNING "Proceeding with defaults."
 else
   source /etc/recap.conf
+fi
+
+# CLI Plugin Actions - (when PLUGIN_ACTION is defined)
+if $( { set -u; echo ${PLUGIN_ACTION}; } &>/dev/null ); then
+  log INFO "CLI Plugin action: ${PLUGIN_ACTION} (${PLUGIN_OPT})"
+  plugin_cli_action "${PLUGIN_ACTION}" "${PLUGIN_OPT}"
+  exit 0
 fi
 
 # Create lock

--- a/src/recap
+++ b/src/recap
@@ -497,7 +497,7 @@ while [[ ${#} -gt 0 ]]; do
       PLUGIN_OPT="${p_args[@]:3}"
 
       # Validate action
-      if ! plugin_validate_action "${PLUGIN_ACTION}"; then
+      if ! validate_plugin_action "${PLUGIN_ACTION}"; then
         echo -e "Error: Invalid plugin action\n" >&2
         print_usage
         exit 1

--- a/src/recap.8
+++ b/src/recap.8
@@ -23,24 +23,44 @@
 .SH NAME
 recap \- dumps periodic information about running applications and resource usage
 .SH SYNOPSIS
-.BI "recap " [OPTION]
+.BI "recap " [OPTIONS]
 .SH DESCRIPTION
 recap is a user\-configurable script that can be run once, or run periodically out of cron or systemd.timers to dump information about running processes and resource usage. It's useful on servers that have periodic, mysterious performance anomalies for tracking down what may be going on at the time of any particular incident.
 
 The values for which reports are generated and how many reports are stored can be overridden in
 .IR /etc/recap.conf "."
 The output files from the script are written to
-.IR BASEDIR "."
+.IR BASEDIR " (default: " /var/log/recap ).
+
+.SH OPTIONS
 .TP
 .BR "\-B, \-\-backup"
 This will perform a "backup". It will copy the latest log files from the last execution to the "backups" directory inside BASEDIR. The files will be identified by a timestamp in the name.
+.TP
+.BI "\-p, \-\-plugin " [ACTIONS]
+Perform plugin related actions: "list", "enable" or "disable".
 .TP
 .BR "\-S, \-\-snapshot"
 This will perform a "snapshot" report. It will generate a set of output files in the "snapshot" directory inside BASEDIR outside of the standard rotation. The files will be identified by a timestamp in the name.
 .TP
 .BR "\-V, \-\-version"
 Print version and exit.
+
+.SH PLUGIN ACTIONS
 .TP
+.BI "list " [TYPE]
+List 'available' (default),'enabled' or 'disabled' plugins.
+.TP
+.BI "enable " [NAME[,NAME]]
+Enable a list of comma separated or 'all' plugins.
+
+Additionally, it will enable the use of plugins
+.RI ( USEPLUGINS="yes" )
+in the config file."
+.TP
+.BI "disable " [NAME[,NAME]]
+Disable a list of comma separated or 'all' plugins.
+
 .SH FILES
 .nf
 /etc/recap.conf


### PR DESCRIPTION
- Add a new option `-p` for plugin actions in `recap`
- Lists, Enables or Disables plugins
- Moves out of recap the plugin functions
- Updates to `man`, `CHANGELOG.md` to reflect new option
- Add testing in travis