### PR TITLE
Add el8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - name: "CentOS 7"
       env:
         - DISTRO='centos:7'
+    - name: "CentOS 8"
+      env:
+        - DISTRO='centos:8'
     - name: "Ubuntu 14.04 (trusty)"
       env:
         - DISTRO='ubuntu:14.04'

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -31,7 +31,7 @@ case ${DISTRO} in
     ;;
   debian*|ubuntu*)
     packages+=(
-               "gawk")
+               "gawk"
                "procps"
                "psmisc"
                "iproute2"

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -16,9 +16,20 @@ packages=(
           )
 
 case ${DISTRO} in
-  centos*|fedora*)
+  fedora*)
     packages+=("iproute")
     yum install ${packages[@]} -y || exit $?
+    ;;
+  centos*)
+    packages+=("iproute")
+    if [[ ${DISTRO/*:/} >= 8 ]]; then
+      dnf --assumeyes \
+        --enablerepo=PowerTools \
+        install ${packages[@]} ||
+      exit $?
+    else
+      yum install ${packages[@]} -y || exit $?
+    fi
     ;;
   debian*|ubuntu*)
     packages+=("iproute2")

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -22,7 +22,7 @@ case ${DISTRO} in
     ;;
   centos*)
     packages+=("iproute")
-    if [[ ${DISTRO/*:/} >= 8 ]]; then
+    if [[ ${DISTRO/*:/} -ge 8 ]]; then
       dnf --assumeyes \
         --enablerepo=PowerTools \
         install ${packages[@]} ||

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -1,38 +1,41 @@
 #!/bin/bash
 
 DISTRO="$1"
+extra_args=""
 
 packages=(
-          "bash"
-          "coreutils"
-          "gawk"
-          "grep"
           "iotop"
           "elinks"
           "make"
-          "procps"
-          "psmisc"
           "sysstat"
           )
 
 case ${DISTRO} in
   fedora*)
-    packages+=("iproute")
-    yum install ${packages[@]} -y || exit $?
+    packages+=(
+               "procps-ng"
+               "psmisc"
+               "iproute"
+    )
+    dnf install --assumeyes ${packages[@]} || exit $?
     ;;
   centos*)
-    packages+=("iproute")
+    packages+=(
+               "psmisc"
+               "iproute"
+    )
     if [[ ${DISTRO/*:/} -ge 8 ]]; then
-      dnf --assumeyes \
-        --enablerepo=PowerTools \
-        install ${packages[@]} ||
-      exit $?
-    else
-      yum install ${packages[@]} -y || exit $?
+      extra_args+="--enablerepo=PowerTools "
     fi
+    yum install --assumeyes ${extra_args} ${packages[@]} || exit $?
     ;;
   debian*|ubuntu*)
-    packages+=("iproute2")
+    packages+=(
+               "gawk")
+               "procps"
+               "psmisc"
+               "iproute2"
+    )
     apt-get update
     apt-get install ${packages[@]} -y || exit $?
     ;;


### PR DESCRIPTION
CentOS 8 was released not long ago, and it was missing from the CI environment, adding it.