### PR TITLE
Add USEMYSQLFULLPROCESSLIST option to mysql plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] -
 - Modify iotop default [#218][218]
 - Add plugin cli support to `recap` [#217][217]
+- Add USEMYSQLFULLPROCESSLIST option to mysql plugin [#231][231]
 
 ## [2.1.0] - 2019-04-12
 - Remove signal `17` in `recaplog` [(#208)][208]

--- a/src/core/mysql
+++ b/src/core/mysql
@@ -94,11 +94,18 @@ print_mysql_innodb_status() {
   log INFO "Ended 'mysql innodb' report"
 }
 
-# Print the output of "mysqladmin processlist" to the mysql file
+# Print the output of "mysqladmin [full] processlist" to the mysql file
 print_mysql_procs() {
-  log INFO "Starting 'mysql processlist' report - ${LOGFILE##*/}"
   local LOGFILE="$1"
   local MYCNF="$2"
+  local FULL="$3"
+  local MY_V=""
+  local MY_PL="processlist"
+  if [[ -n "${FULL}" ]]; then
+    MY_PL="full processlist"
+    MY_V="-v"
+  fi
+  log INFO "Starting 'mysql ${MY_PL}' report - ${LOGFILE##*/}"
   local PLESK_FILE="/etc/psa/.psa.shadow"
   if [[ -r "${PLESK_FILE}" ]]; then
     echo "MySQL (plesk) processes" >> "${LOGFILE}"
@@ -106,7 +113,7 @@ print_mysql_procs() {
       mysqladmin \
         -uadmin \
         -p$( cat "${PLESK_FILE}" ) \
-        -v processlist \
+        ${MY_V} processlist \
         --connect-timeout=5 \
         >> "${LOGFILE}"
     fi
@@ -115,7 +122,7 @@ print_mysql_procs() {
         -uadmin \
         -p$( cat "${PLESK_FILE}" ) \
         --connect-timeout=5 \
-        -e "show full processlist\G" \
+        -e "show ${MY_PL}\G" \
         >> "${LOGFILE}"
     fi
   else
@@ -123,17 +130,17 @@ print_mysql_procs() {
     if [[ ${MYSQL_PROCESS_LIST} == "table" ]]; then
       mysqladmin \
         --defaults-file="${MYCNF}" \
-        -v processlist \
+        ${MY_V} processlist \
         --connect-timeout=5 \
         >> "${LOGFILE}"
     elif [[ ${MYSQL_PROCESS_LIST,,} == "vertical" ]]; then
       mysql \
         --defaults-file="${MYCNF}" \
         --connect-timeout=5 \
-        -e "show full processlist\G" \
+        -e "show ${MY_PL}\G" \
         >> "${LOGFILE}"
     fi
   fi
   print_blankline "${LOGFILE}"
-  log INFO "Ended 'mysql processlist' report"
+  log INFO "Ended 'mysql ${MY_PL}' report"
 }

--- a/src/core/mysql
+++ b/src/core/mysql
@@ -94,7 +94,7 @@ print_mysql_innodb_status() {
   log INFO "Ended 'mysql innodb' report"
 }
 
-# Print the output of "mysqladmin [full] processlist" to the mysql file
+# Print the output of "mysql [full] processlist" to the mysql file
 print_mysql_procs() {
   local LOGFILE="$1"
   local MYCNF="$2"

--- a/src/recap
+++ b/src/recap
@@ -99,10 +99,12 @@ declare -r default_DOTMYDOTCNF="/root/.my.cnf"
 declare -r default_MYSQL_PROCESS_LIST="table"
 declare -r default_USEINNODB="no"
 declare -r default_USEMYSQLPROCESSLIST="no"
+declare -r default_USEMYSQLFULLPROCESSLIST="no"
 DOTMYDOTCNF="${default_DOTMYDOTCNF}"
 MYSQL_PROCESS_LIST="${default_MYSQL_PROCESS_LIST}"
 USEINNODB="${default_USEINNODB}"
 USEMYSQLPROCESSLIST="${default_USEMYSQLPROCESSLIST}"
+USEMYSQLFULLPROCESSLIST="${default_USEMYSQLFULLPROCESSLIST}"
 
 # Default command options(can be overridden in config file)
 declare -r default_OPTS_DF="-x nfs"
@@ -373,6 +375,10 @@ run_mysql_report() {
     if [[ "${USEMYSQLPROCESSLIST,,}" == "yes" ]]; then
       print_blankline "${ITEM_FILE}"
       print_mysql_procs "${ITEM_FILE}" "${MYCNF}"
+    fi
+    if [[ "${USEMYSQLFULLPROCESSLIST,,}" == "yes" ]]; then
+      print_blankline "${ITEM_FILE}"
+      print_mysql_procs "${ITEM_FILE}" "${MYCNF}" "FULL"
     fi
     if [[ "${USEINNODB,,}" == "yes" ]]; then
       # send df -h output to output file

--- a/src/recap
+++ b/src/recap
@@ -372,13 +372,12 @@ run_mysql_report() {
     print_mysql "${ITEM_FILE}" "${MYCNF}"
 
     # check to see if the optional mysql process list should be generated
-    if [[ "${USEMYSQLPROCESSLIST,,}" == "yes" ]]; then
-      print_blankline "${ITEM_FILE}"
-      print_mysql_procs "${ITEM_FILE}" "${MYCNF}"
-    fi
     if [[ "${USEMYSQLFULLPROCESSLIST,,}" == "yes" ]]; then
       print_blankline "${ITEM_FILE}"
       print_mysql_procs "${ITEM_FILE}" "${MYCNF}" "FULL"
+    elif [[ "${USEMYSQLPROCESSLIST,,}" == "yes" ]]; then
+      print_blankline "${ITEM_FILE}"
+      print_mysql_procs "${ITEM_FILE}" "${MYCNF}"
     fi
     if [[ "${USEINNODB,,}" == "yes" ]]; then
       # send df -h output to output file

--- a/src/recap.conf
+++ b/src/recap.conf
@@ -59,7 +59,7 @@
 ## Report: mysql
 # USEMYSQL - Generates logs from "mysqladmin status"
 # makes use of DOTMYDOTCNF.
-# Required by: USEMYSQLPROCESSLIST, USEINNODB
+# Required by: USEMYSQLPROCESSLIST, USEMYSQLFULLPROCESSLIST, USEINNODB
 # Example, to enable: USEMYSQL="yes"
 #USEMYSQL="no"
 
@@ -68,6 +68,12 @@
 # requires: USEMYSQL
 # Example, to enable: USEMYSQLPROCESSLIST="yes"
 #USEMYSQLPROCESSLIST="no"
+
+# USEMYSQLFULLPROCESSLIST - Generates logs from "mysqladmin -v processlist"
+# Makes use of DOTMYDOTCNF and MYSQL_PROCESS_LIST
+# requires: USEMYSQL
+# Example, to enable: USEMYSQLFULLPROCESSLIST="yes"
+#USEMYSQLFULLPROCESSLIST="no"
 
 # USEINNODB - Generates logs from "mysql show engine innodb status"
 # Makes use of DOTMYDOTCNF
@@ -145,9 +151,9 @@
 #DOTMYDOTCNF="/root/.my.cnf"
 
 # MYSQL_PROCESS_LIST - Format  to  display MySQL process list, options are
-# "table" or  "vertical".  This  requires  that  USEMYSQLPROCESSLIST be set
-# "yes".
-# Required by: USEMYSQLPROCESSLIST
+# "table" or  "vertical".  This  requires  that  USEMYSQLPROCESSLIST and/or
+# USEMYSQLFULLPROCESSLIST set to "yes".
+# Required by: USEMYSQLPROCESSLIST, USEMYSQLFULLPROCESSLIST
 # Example, generate vertical output: MYSQL_PROCESS_LIST="vertical"
 #MYSQL_PROCESS_LIST="table"
 

--- a/src/recap.conf.5
+++ b/src/recap.conf.5
@@ -118,6 +118,12 @@ Can be set to yes or no depending on whether or not the output of "mysqladmin pr
 .IR ${BASEDIR}/mysql.log
 (default: no)
 
+.IP \fBUSEMYSQLFULLPROCESSLIST\fR
+.br
+Can be set to yes or no depending on whether or not the output of "mysqladmin -v processlist" command should be recorded. This report requires that USEMYSQL be set to "yes". This option makes use of MYSQL_PROCESS_LIST, to produce the output vertical or in a table. This output is written in
+.IR ${BASEDIR}/mysql.log
+(default: no)
+
 .IP \fBUSEINNODB\fR
 .br
 Can be set to yes or no depending on whether or not the output of "mysql show engine innodb status" and other variables(pid_files, tmpdir) command should be recorded. This report requires that USEMYSQL be set to "yes". This output is written in
@@ -131,12 +137,12 @@ Options used by the tools generating the reports
 
 .IP \fBDOTMYDOTCNF\fR
 .br
-Option required by USEMYSQL, USEMYSQLPROCESSLIST, USEINNODB, defines the path to the mysql client configuration file.
+Option required by USEMYSQL, USEMYSQLPROCESSLIST, USEMYSQLFULLPROCESSLIST, USEINNODB, defines the path to the mysql client configuration file.
 (default: "/root/.my.cnf")
 
 .IP \fBMYSQL_PROCESS_LIST\fR
 .br
-Format to display MySQL process list, options are "table" or "vertical". This requires that USEMYSQLPROCESSLIST be set "yes".
+Format to display MySQL process list, options are "table" or "vertical". This requires that USEMYSQLPROCESSLIST and/or USEMYSQLFULLPROCESSLIST to be set to "yes".
 (default: table).
 
 .IP \fBOPTS_LINKS\fR

--- a/src/recap.conf.5
+++ b/src/recap.conf.5
@@ -120,7 +120,7 @@ Can be set to yes or no depending on whether or not the output of "mysqladmin pr
 
 .IP \fBUSEMYSQLFULLPROCESSLIST\fR
 .br
-Can be set to yes or no depending on whether or not the output of "mysqladmin -v processlist" command should be recorded. This report requires that USEMYSQL be set to "yes". This option makes use of MYSQL_PROCESS_LIST, to produce the output vertical or in a table. This output is written in
+Can be set to yes or no depending on whether or not the output of "mysqladmin -v processlist" command should be recorded. This report requires that USEMYSQL be set to "yes". This option takes priority over USEMYSQLPROCESSLIST. This option makes use of MYSQL_PROCESS_LIST, to produce the output vertical or in a table. This output is written in
 .IR ${BASEDIR}/mysql.log
 (default: no)
 


### PR DESCRIPTION
Fixes #231 

- Modifies the `USEMYSQLPROCESSLIST` to be truly "show processlist"
- Adds a new option `USEMYSQLFULLPROCESSLIST`, this option perfoms a "show full processlist", this was the original functionality of `USEMYSQLPROCESSLIST`

---

Ran a test that shows the two different outputs ("show processlist" and "show full processlist") in this [gist](https://gist.github.com/tonyskapunk/2429607c0e21c9a09f35e887c6b5e7da)