### PR TITLE
Fixed InnoDB report not working when tmpdir is a symlink

### DIFF
--- a/src/core/mysql
+++ b/src/core/mysql
@@ -74,6 +74,11 @@ print_mysql_innodb_status() {
   if [[ "${PID_FILE}" =~ ^[^/] ]]; then
     PID_FILE="${MYVALS[5]%/}/${PID_FILE}"
   fi
+  # If tmpdir points to a symlink we need to use the destination folder
+  # because the temporary files under /proc will point to that folder:
+  if [[ -L "${TMPDIR}" ]]; then
+     TMPDIR="$(readlink -f "${TMPDIR}")"
+  fi
 
   # Next, we grab a list of descriptors in the tmpdir:
   if [[ -r "${PID_FILE}" &&


### PR DESCRIPTION
Re #238
I just changed print_mysql_innodb_status to add a check if TMPDIR is a symlink and eventually replace replace it with the destination.