### PR TITLE
Add exit to check_disk_space

### DIFF
--- a/src/recap
+++ b/src/recap
@@ -472,6 +472,10 @@ check_disk_space() {
     FREE_SPACE=${FREE_SPACE%M}
     if [[ "${MIN_FREE_SPACE}" -ge "${FREE_SPACE}" ]]; then
       log ERROR "Unable to run recap due to not enough disk space"
+      if [[ -n "${MAILTO}" ]]; then
+        send_mail
+      fi
+      exit 1
     fi
   fi
   log INFO "Ended check for disk space"


### PR DESCRIPTION
Currently recap decides not to run and then creates new files anyway, when testing with MIN_FREE_SPACE=999999999